### PR TITLE
Reduce memory reading time by 99%

### DIFF
--- a/Helpers/ProcessContext.cs
+++ b/Helpers/ProcessContext.cs
@@ -51,7 +51,6 @@ namespace MapAssist.Helpers
             var handle = GCHandle.Alloc(buf, GCHandleType.Pinned);
             try
             {
-                IntPtr processAddress = _process.MainModule.BaseAddress;
                 WindowsExternal.ReadProcessMemory(_handle, address, buf, buf.Length, out _);
                 var result = new T[count];
                 for (var i = 0; i < count; i++)


### PR DESCRIPTION
After profiling a bit I noticed that a lot of our time was spent reading memory for units. Digging further I found that 99% of that time is spent resolving the MainModule of the process. We don't seem to even be using this.