### PR TITLE
feat: configurable Monster Icons

### DIFF
--- a/App.config
+++ b/App.config
@@ -33,11 +33,11 @@
         <add key="HiddenAreas" value="Rogue Encampment,Lut Gholein,Kurast Docktown,The Pandemonium Fortress,Harrogath,Forgotten Tower,Nihlathaks Temple" />
 
         <add key="EliteMonster.IconColor" value="DarkOrange" />
-        <add key="EliteMonster.IconShape" value="OpenSquare" />
+        <add key="EliteMonster.IconShape" value="SquareOutline" />
         <add key="EliteMonster.IconSize" value="6" />
 
         <add key="NormalMonster.IconColor" value="DarkRed" />
-        <add key="NormalMonster.IconShape" value="OpenSquare" />
+        <add key="NormalMonster.IconShape" value="SquareOutline" />
         <add key="NormalMonster.IconSize" value="6" />
 
         <add key="Waypoint.IconColor" value="16, 140, 235" />

--- a/App.config
+++ b/App.config
@@ -32,15 +32,20 @@
         <add key="PrefetchAreas" value="Catacombs Level 2,Durance Of Hate Level 2" />
         <add key="HiddenAreas" value="Rogue Encampment,Lut Gholein,Kurast Docktown,The Pandemonium Fortress,Harrogath,Forgotten Tower,Nihlathaks Temple" />
 
-        <add key="MonsterColor.Normal" value="DarkRed"/>
-        <add key="MonsterColor.Elite" value="DarkOrange"/>
+        <add key="EliteMonster.IconColor" value="DarkOrange" />
+        <add key="EliteMonster.IconShape" value="OpenSquare" />
+        <add key="EliteMonster.IconSize" value="6" />
+
+        <add key="NormalMonster.IconColor" value="DarkRed" />
+        <add key="NormalMonster.IconShape" value="OpenSquare" />
+        <add key="NormalMonster.IconSize" value="6" />
 
         <add key="Waypoint.IconColor" value="16, 140, 235" />
-        <add key="Waypoint.IconShape" value="Rectangle" />
+        <add key="Waypoint.IconShape" value="Square" />
         <add key="Waypoint.IconSize" value="10" />
 
         <add key="Player.IconColor" value="255, 255, 0" />
-        <add key="Player.IconShape" value="Rectangle" />
+        <add key="Player.IconShape" value="Square" />
         <add key="Player.IconSize" value="5" />
 
         <add key="SuperChest.IconColor" value="17, 255, 0" />
@@ -52,14 +57,14 @@
         <add key="Shrine.IconSize" value="10" />
 
         <add key="NextArea.IconColor" value="237, 107, 0" />
-        <add key="NextArea.IconShape" value="Rectangle" />
+        <add key="NextArea.IconShape" value="Square" />
         <add key="NextArea.IconSize" value="10" />
         <add key="NextArea.LabelColor" value="Chartreuse" />
         <add key="NextArea.LineColor" value="Chartreuse" />
         <add key="NextArea.ArrowHeadSize" value="10" />
 
         <add key="PreviousArea.IconColor" value="255, 0, 149" />
-        <add key="PreviousArea.IconShape" value="Rectangle" />
+        <add key="PreviousArea.IconShape" value="Square" />
         <add key="PreviousArea.IconSize" value="10" />
         <add key="PreviousArea.LabelColor" value="Chartreuse" />
 

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -247,16 +247,13 @@ namespace MapAssist.Helpers
                     switch (poiSettings.IconShape)
                     {
                         case Shape.Ellipse:
-                            g.FillEllipse(brush, 0, 0, poiSettings.IconSize,
-                                poiSettings.IconSize);
+                            g.FillEllipse(brush, 0, 0, poiSettings.IconSize, poiSettings.IconSize);
                             break;
                         case Shape.Square:
-                            g.FillRectangle(brush, 0, 0, poiSettings.IconSize,
-                                poiSettings.IconSize);
+                            g.FillRectangle(brush, 0, 0, poiSettings.IconSize, poiSettings.IconSize);
                             break;
                         case Shape.OpenSquare:
-                            g.DrawRectangle(pen, 0, 0, poiSettings.IconSize - 1,
-                                poiSettings.IconSize - 1);
+                            g.DrawRectangle(pen, 0, 0, poiSettings.IconSize - 1, poiSettings.IconSize - 1);
                             break;
                         case Shape.Polygon:
                             var halfSize = poiSettings.IconSize / 2;

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -97,31 +97,39 @@ namespace MapAssist.Helpers
                         imageGraphics.DrawLine(pen, localPlayerCenterPosition, poiPosition);
                     }
                 }
-                
+
                 foreach (var unitAny in gameData.Monsters)
                 {
                     var mobRender = unitAny.IsElite() ? Rendering.EliteMonster : Rendering.NormalMonster;
 
-                    // Draw Monster Icon
-                    Bitmap icon = GetIcon(mobRender);
-                    Point origin = unitAny.Position
-                        .OffsetFrom(_areaData.Origin)
-                        .OffsetFrom(CropOffset)
-                        .OffsetFrom(GetIconOffset(mobRender.IconSize));
-                    imageGraphics.DrawImage(icon, origin);
-
-                    // Draw Monster Immunities
-                    var immunityCount = unitAny.Immunities.Count;
-                    var baseY = immunityCount - 1;
-                    var baseX = -baseY;
-                    foreach (var immunity in unitAny.Immunities)
+                    if (mobRender.CanDrawIcon())
                     {
-                        var iPoint = new Point(baseX, baseY);
-                        var brush = new SolidBrush(ResistColors.ResistColor[immunity]);
-                        var rect2 = new Rectangle(origin.OffsetFrom(iPoint), new Size(2, 2));
-                        imageGraphics.FillRectangle(brush, rect2);
-                        baseY -= 2;
-                        baseX += 2;
+                        // Draw Monster Icon
+                        Bitmap icon = GetIcon(mobRender);
+                        Point origin = unitAny.Position
+                            .OffsetFrom(_areaData.Origin)
+                            .OffsetFrom(CropOffset)
+                            .OffsetFrom(GetIconOffset(mobRender.IconSize));
+                        imageGraphics.DrawImage(icon, origin);
+
+                        // Draw Monster Immunities
+                        var iCount = unitAny.Immunities.Count;
+                        if (iCount > 0)
+                        {
+                            var extraOffset = mobRender.IconShape == Shape.Cross;
+                            var iY = extraOffset ? --iCount : iCount;
+                            var iX = extraOffset ? -iY : -(iY - 2);
+
+                            foreach (var immunity in unitAny.Immunities)
+                            {
+                                var iPoint = new Point(iX, iY);
+                                var brush = new SolidBrush(ResistColors.ResistColor[immunity]);
+                                var rect2 = new Rectangle(origin.OffsetFrom(iPoint), new Size(2, 2));
+                                imageGraphics.FillRectangle(brush, rect2);
+                                iY -= 2;
+                                iX += 2;
+                            }
+                        }
                     }
                 }
             }

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -116,16 +116,16 @@ namespace MapAssist.Helpers
                         var iCount = unitAny.Immunities.Count;
                         if (iCount > 0)
                         {
-                            var extraOffset = mobRender.IconShape == Shape.Cross;
-                            var iY = extraOffset ? --iCount : iCount;
-                            var iX = extraOffset ? -iY : -(iY - 2);
+                            var shortOffset = mobRender.IconShape == Shape.Cross;
+                            var iY = shortOffset ? --iCount : iCount;
+                            var iX = shortOffset ? -iY : -(iY - 2);
 
                             foreach (var immunity in unitAny.Immunities)
                             {
                                 var iPoint = new Point(iX, iY);
                                 var brush = new SolidBrush(ResistColors.ResistColor[immunity]);
-                                var rect2 = new Rectangle(origin.OffsetFrom(iPoint), new Size(2, 2));
-                                imageGraphics.FillRectangle(brush, rect2);
+                                var rect = new Rectangle(origin.OffsetFrom(iPoint), new Size(2, 2));
+                                imageGraphics.FillRectangle(brush, rect);
                                 iY -= 2;
                                 iX += 2;
                             }

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -97,27 +97,31 @@ namespace MapAssist.Helpers
                         imageGraphics.DrawLine(pen, localPlayerCenterPosition, poiPosition);
                     }
                 }
-                MonsterRendering renderMonster = Utils.GetMonsterRendering();
+                
                 foreach (var unitAny in gameData.Monsters)
                 {
-                    var clr = unitAny.IsElite() ? renderMonster.EliteColor : renderMonster.NormalColor;
-                    var pen = new Pen(clr, 1);
-                    var sz = new Size(5, 5);
-                    var sz2 = new Size(2, 2);
-                    var pos = new Point(unitAny.Path.DynamicX, unitAny.Path.DynamicY);
-                    var midPoint = pos.OffsetFrom(_areaData.Origin).OffsetFrom(CropOffset);
-                    var rect = new Rectangle(midPoint, sz);
-                    imageGraphics.DrawRectangle(pen, rect);
-                    var i = 0;
+                    var mobRender = unitAny.IsElite() ? Rendering.EliteMonster : Rendering.NormalMonster;
+
+                    // Draw Monster Icon
+                    Bitmap icon = GetIcon(mobRender);
+                    Point origin = unitAny.Position
+                        .OffsetFrom(_areaData.Origin)
+                        .OffsetFrom(CropOffset)
+                        .OffsetFrom(GetIconOffset(mobRender.IconSize));
+                    imageGraphics.DrawImage(icon, origin);
+
+                    // Draw Monster Immunities
+                    var immunityCount = unitAny.Immunities.Count;
+                    var baseY = immunityCount - 1;
+                    var baseX = -baseY;
                     foreach (var immunity in unitAny.Immunities)
                     {
+                        var iPoint = new Point(baseX, baseY);
                         var brush = new SolidBrush(ResistColors.ResistColor[immunity]);
-                        //shove the point we're drawing the immunity at to the left to align based on number of immunities
-                        var iPoint = new Point((i * -2) + (1 * (unitAny.Immunities.Count - 1)) - 1, 3);
-                        var pen2 = new Pen(ResistColors.ResistColor[immunity], 1);
-                        var rect2 = new Rectangle(midPoint.OffsetFrom(iPoint), sz2);
+                        var rect2 = new Rectangle(origin.OffsetFrom(iPoint), new Size(2, 2));
                         imageGraphics.FillRectangle(brush, rect2);
-                        i++;
+                        baseY -= 2;
+                        baseX += 2;
                     }
                 }
             }
@@ -228,18 +232,23 @@ namespace MapAssist.Helpers
             {
                 var bitmap = new Bitmap(poiSettings.IconSize, poiSettings.IconSize, PixelFormat.Format32bppArgb);
                 var pen = new Pen(poiSettings.IconColor, poiSettings.LineThickness);
+                var brush = new SolidBrush(poiSettings.IconColor);
                 using (var g = Graphics.FromImage(bitmap))
                 {
                     g.SmoothingMode = SmoothingMode.HighQuality;
                     switch (poiSettings.IconShape)
                     {
                         case Shape.Ellipse:
-                            g.FillEllipse(new SolidBrush(poiSettings.IconColor), 0, 0, poiSettings.IconSize,
+                            g.FillEllipse(brush, 0, 0, poiSettings.IconSize,
                                 poiSettings.IconSize);
                             break;
-                        case Shape.Rectangle:
-                            g.FillRectangle(new SolidBrush(poiSettings.IconColor), 0, 0, poiSettings.IconSize,
+                        case Shape.Square:
+                            g.FillRectangle(brush, 0, 0, poiSettings.IconSize,
                                 poiSettings.IconSize);
+                            break;
+                        case Shape.OpenSquare:
+                            g.DrawRectangle(pen, 0, 0, poiSettings.IconSize - 1,
+                                poiSettings.IconSize - 1);
                             break;
                         case Shape.Polygon:
                             var halfSize = poiSettings.IconSize / 2;
@@ -254,7 +263,7 @@ namespace MapAssist.Helpers
                                 new PointF(halfSize, poiSettings.IconSize),
                                 new PointF(halfSize - cutSize, halfSize + cutSize)
                             };
-                            g.FillPolygon(new SolidBrush(poiSettings.IconColor), curvePoints);
+                            g.FillPolygon(brush, curvePoints);
                             break;
                         case Shape.Cross:
                             var a = poiSettings.IconSize * 0.0833333f;

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -228,18 +228,18 @@ namespace MapAssist.Helpers
             return _fontCache[cacheKey];
         }
 
-        private Bitmap GetIcon(PointOfInterestRendering poiSettings)
+        private Bitmap GetIcon(IconRendering poiSettings)
         {
             (Shape IconShape, int IconSize, Color Color, float LineThickness) cacheKey = (
                 poiSettings.IconShape,
                 poiSettings.IconSize,
                 poiSettings.IconColor,
-                poiSettings.LineThickness
+                poiSettings.IconThickness
             );
             if (!_iconCache.ContainsKey(cacheKey))
             {
                 var bitmap = new Bitmap(poiSettings.IconSize, poiSettings.IconSize, PixelFormat.Format32bppArgb);
-                var pen = new Pen(poiSettings.IconColor, poiSettings.LineThickness);
+                var pen = new Pen(poiSettings.IconColor, poiSettings.IconThickness);
                 var brush = new SolidBrush(poiSettings.IconColor);
                 using (var g = Graphics.FromImage(bitmap))
                 {

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -252,7 +252,7 @@ namespace MapAssist.Helpers
                         case Shape.Square:
                             g.FillRectangle(brush, 0, 0, poiSettings.IconSize, poiSettings.IconSize);
                             break;
-                        case Shape.OpenSquare:
+                        case Shape.SquareOutline:
                             g.DrawRectangle(pen, 0, 0, poiSettings.IconSize - 1, poiSettings.IconSize - 1);
                             break;
                         case Shape.Polygon:

--- a/Settings/PointOfInterestRendering.cs
+++ b/Settings/PointOfInterestRendering.cs
@@ -21,12 +21,21 @@ using System.Drawing;
 
 namespace MapAssist.Settings
 {
-    public class PointOfInterestRendering
+    public class IconRendering
     {
         public Color IconColor;
         public Shape IconShape;
         public int IconSize;
+        public float IconThickness;
 
+        public bool CanDrawIcon()
+        {
+            return IconShape != Shape.None && IconSize > 0 && IconColor != Color.Transparent;
+        }
+    }
+
+    public class PointOfInterestRendering : IconRendering
+    {
         public Color LineColor;
         public float LineThickness;
 
@@ -35,11 +44,6 @@ namespace MapAssist.Settings
         public Color LabelColor;
         public string LabelFont;
         public int LabelFontSize;
-
-        public bool CanDrawIcon()
-        {
-            return IconShape != Shape.None && IconSize > 0 && IconColor != Color.Transparent;
-        }
 
         public bool CanDrawLine()
         {

--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -45,8 +45,8 @@ namespace MapAssist.Settings
         public static PointOfInterestRendering NormalChest = Utils.GetRenderingSettingsForPrefix("NormalChest");
         public static PointOfInterestRendering ArmorWeapRack = Utils.GetRenderingSettingsForPrefix("ArmorWeapRack");
 
-        public static IconRendering EliteMonster = Utils.GetRenderingSettingsForPrefix("EliteMonster");
-        public static IconRendering NormalMonster = Utils.GetRenderingSettingsForPrefix("NormalMonster");
+        public static IconRendering EliteMonster = Utils.GetIconRenderingSettingsForPrefix("EliteMonster");
+        public static IconRendering NormalMonster = Utils.GetIconRenderingSettingsForPrefix("NormalMonster");
     }
 
     public static class Map

--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -45,8 +45,8 @@ namespace MapAssist.Settings
 
         public static PointOfInterestRendering Shrine = Utils.GetRenderingSettingsForPrefix("Shrine");
 
-        public static PointOfInterestRendering EliteMonster = Utils.GetRenderingSettingsForPrefix("EliteMonster");
-        public static PointOfInterestRendering NormalMonster = Utils.GetRenderingSettingsForPrefix("NormalMonster");
+        public static IconRendering EliteMonster = Utils.GetRenderingSettingsForPrefix("EliteMonster");
+        public static IconRendering NormalMonster = Utils.GetRenderingSettingsForPrefix("NormalMonster");
     }
 
     public static class Map

--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -44,6 +44,9 @@ namespace MapAssist.Settings
             Utils.GetRenderingSettingsForPrefix("SuperChest");
 
         public static PointOfInterestRendering Shrine = Utils.GetRenderingSettingsForPrefix("Shrine");
+
+        public static PointOfInterestRendering EliteMonster = Utils.GetRenderingSettingsForPrefix("EliteMonster");
+        public static PointOfInterestRendering NormalMonster = Utils.GetRenderingSettingsForPrefix("NormalMonster");
     }
 
     public static class Map

--- a/Settings/Shape.cs
+++ b/Settings/Shape.cs
@@ -26,6 +26,6 @@ namespace MapAssist.Settings
         Ellipse,
         Polygon,
         Cross,
-        OpenSquare,
+        SquareOutline,
     }
 }

--- a/Settings/Shape.cs
+++ b/Settings/Shape.cs
@@ -22,9 +22,10 @@ namespace MapAssist.Settings
     public enum Shape
     {
         None,
-        Rectangle,
+        Square,
         Ellipse,
         Polygon,
-        Cross
+        Cross,
+        OpenSquare,
     }
 }

--- a/Settings/Utils.cs
+++ b/Settings/Utils.cs
@@ -93,13 +93,5 @@ namespace MapAssist.Settings
                 LabelFontSize = GetConfigValue($"{name}.LabelFontSize", Convert.ToInt32, 8),
             };
         }
-        public static MonsterRendering GetMonsterRendering()
-        {
-            return new MonsterRendering
-            {
-                NormalColor = GetConfigValue($"MonsterColor.Normal", ParseColor, Color.Transparent),
-                EliteColor = GetConfigValue($"MonsterColor.Elite", ParseColor, Color.Transparent)
-            };
-        }
     }
 }

--- a/Settings/Utils.cs
+++ b/Settings/Utils.cs
@@ -78,6 +78,17 @@ namespace MapAssist.Settings
             return Color.FromName(value);
         }
 
+        public static IconRendering GetIconRenderingSettingsForPrefix(string name)
+        {
+            return new IconRendering
+            {
+                IconColor = GetConfigValue($"{name}.IconColor", ParseColor, Color.Transparent),
+                IconShape = GetConfigValue($"{name}.IconShape", t => (Shape)Enum.Parse(typeof(Shape), t, true)),
+                IconSize = GetConfigValue($"{name}.IconSize", Convert.ToInt32),
+                IconThickness = GetConfigValue($"{name}.IconThickness", Convert.ToSingle, CultureInfo.InvariantCulture, 1f),
+            };
+        }
+
         public static PointOfInterestRendering GetRenderingSettingsForPrefix(string name)
         {
             return new PointOfInterestRendering
@@ -85,8 +96,9 @@ namespace MapAssist.Settings
                 IconColor = GetConfigValue($"{name}.IconColor", ParseColor, Color.Transparent),
                 IconShape = GetConfigValue($"{name}.IconShape", t => (Shape)Enum.Parse(typeof(Shape), t, true)),
                 IconSize = GetConfigValue($"{name}.IconSize", Convert.ToInt32),
+                IconThickness = GetConfigValue($"{name}.IconThickness", Convert.ToSingle, CultureInfo.InvariantCulture, 1f),
                 LineColor = GetConfigValue($"{name}.LineColor", ParseColor, Color.Transparent),
-                LineThickness = GetConfigValue($"{name}.LineThickness", Convert.ToSingle, CultureInfo.InvariantCulture, 1.0f),
+                LineThickness = GetConfigValue($"{name}.LineThickness", Convert.ToSingle, CultureInfo.InvariantCulture, 1f),
                 ArrowHeadSize = GetConfigValue($"{name}.ArrowHeadSize", Convert.ToInt32),
                 LabelColor = GetConfigValue($"{name}.LabelColor", ParseColor, Color.Transparent),
                 LabelFont = GetConfigValue($"{name}.LabelFont", t => t, "Arial"),


### PR DESCRIPTION
### Description
App config uses `EliteMonster` and `NormalMonster` like other POI render settings to make monster icons more configurable.

Monster immunity dot positions were changed to top-center for better compatibility with `Cross` icon.

`Rectangle` Icon name changed to `Square` (since we're drawing a Square) and a `SquareOutline` icon was added (keeping the default Monster icon shape the same)

### Screenshots
Defaults, showing monsters with `OpenSquare` icon
![open-square](https://user-images.githubusercontent.com/10291543/142718297-89dfffcb-696d-4786-a7ef-514d87465f25.png)

Example of `Cross` icon for comparison
![cross](https://user-images.githubusercontent.com/10291543/142718242-b997f625-cc34-47ed-81cd-c25f6bc24bf9.png)