### PR TITLE
Fix exit button and improve tray icon context menu

### DIFF
--- a/Overlay.cs
+++ b/Overlay.cs
@@ -27,7 +27,6 @@ using SharpDX.Direct2D1;
 using SharpDX.Mathematics.Interop;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -37,7 +36,6 @@ using Bitmap = System.Drawing.Bitmap;
 using Color = GameOverlay.Drawing.Color;
 using Font = GameOverlay.Drawing.Font;
 using Graphics = GameOverlay.Drawing.Graphics;
-using Image = GameOverlay.Drawing.Image;
 using Point = GameOverlay.Drawing.Point;
 using SolidBrush = GameOverlay.Drawing.SolidBrush;
 
@@ -46,8 +44,6 @@ namespace MapAssist
     public class Overlay : IDisposable
     {
         private readonly GraphicsWindow _window;
-
-        private System.Windows.Forms.NotifyIcon _trayIcon;
 
         private GameData _currentGameData;
         private GameDataCache _gameDataCache;
@@ -61,7 +57,7 @@ namespace MapAssist
         public Overlay(IKeyboardMouseEvents keyboardMouseEvents)
         {
             _gameDataCache = new GameDataCache();
-            
+
             var gfx = new Graphics() {MeasureFPS = true};
 
             _brushes = new Dictionary<string, SolidBrush>();
@@ -103,23 +99,6 @@ namespace MapAssist
                     }
                 }
             };
-
-            _trayIcon = new System.Windows.Forms.NotifyIcon()
-            {
-                Icon = Properties.Resources.Icon1,
-                ContextMenu =
-                    new System.Windows.Forms.ContextMenu(
-                        new System.Windows.Forms.MenuItem[] {new System.Windows.Forms.MenuItem("Exit", Exit)}),
-                Text = "MapAssist",
-                Visible = true
-            };
-        }
-
-        void Exit(object sender, EventArgs e)
-        {
-            _trayIcon.Visible = false;
-
-            Dispose();
         }
 
         private void _window_SetupGraphics(object sender, SetupGraphicsEventArgs e)

--- a/Program.cs
+++ b/Program.cs
@@ -28,6 +28,9 @@ namespace MapAssist
 {
     static class Program
     {
+        private static string appName = "MapAssist";
+        private static Mutex mutex = null; 
+        
         private static NotifyIcon trayIcon;
         private static Overlay overlay;
         private static BackgroundWorker backWorkOverlay = new BackgroundWorker();
@@ -40,6 +43,15 @@ namespace MapAssist
         {
             try
             {
+                bool createdNew;
+                mutex = new Mutex(true, appName, out createdNew);
+
+                if (!createdNew)
+                {
+                    //app is already running! Exiting the application  
+                    return;
+                }
+
                 var configurationOk = LoadMainConfiguration() && LoadLootLogConfiguration();
                 if (configurationOk)
                 {
@@ -59,7 +71,7 @@ namespace MapAssist
                     {
                         Icon = Properties.Resources.Icon1,
                         ContextMenuStrip = contextMenu,
-                        Text = "MapAssist",
+                        Text = appName,
                         Visible = true
                     };
 
@@ -157,6 +169,8 @@ namespace MapAssist
             {
                 backWorkOverlay.CancelAsync();
             }
+
+            mutex.Dispose();
 
             Application.Exit();
         }

--- a/Program.cs
+++ b/Program.cs
@@ -23,6 +23,7 @@ using System.Windows.Forms;
 using Gma.System.MouseKeyHook;
 using MapAssist.Settings;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace MapAssist
 {
@@ -68,8 +69,19 @@ namespace MapAssist
 
                     var contextMenu = new ContextMenuStrip();
 
+                    var configMenuItem = new ToolStripMenuItem("Config", null, Config);
+                    var lootFilterMenuItem = new ToolStripMenuItem("Loot Filter", null, LootFilter);
+                    var restartMenuItem = new ToolStripMenuItem("Restart", null, Restart);
                     var exitMenuItem = new ToolStripMenuItem("Exit", null, Exit);
                     contextMenu.Items.Add(exitMenuItem);
+
+                    contextMenu.Items.AddRange(new ToolStripItem[] {
+                        configMenuItem,
+                        lootFilterMenuItem,
+                        new ToolStripSeparator(),
+                        restartMenuItem,
+                        exitMenuItem
+                    });
 
                     trayIcon = new NotifyIcon()
                     {
@@ -163,7 +175,19 @@ namespace MapAssist
             return configurationOk;
         }
 
-        private static void Exit(object sender, EventArgs e)
+        private static void Config(object sender, EventArgs e)
+        {
+            var _path = AppDomain.CurrentDomain.BaseDirectory;
+            Process.Start(_path + "\\Config.yaml");
+        }
+
+        private static void LootFilter(object sender, EventArgs e)
+        {
+            var _path = AppDomain.CurrentDomain.BaseDirectory;
+            Process.Start(_path + "\\ItemFilter.yaml");
+        }
+
+        private static void Dispose()
         {
             trayIcon.Visible = false;
 
@@ -175,6 +199,18 @@ namespace MapAssist
             }
 
             mutex.Dispose();
+        }
+
+        private static void Restart(object sender, EventArgs e)
+        {
+            Dispose();
+
+            Application.Restart();
+        }
+
+        private static void Exit(object sender, EventArgs e)
+        {
+            Dispose();
 
             Application.Exit();
         }

--- a/Program.cs
+++ b/Program.cs
@@ -48,7 +48,11 @@ namespace MapAssist
 
                 if (!createdNew)
                 {
-                    //app is already running! Exiting the application  
+                    var rand = new Random();
+                    var isGemActive = rand.NextDouble() < 0.05;
+
+                    MessageBox.Show("An instance of " + appName + " is already running." + (isGemActive ? " Better go catch it!" : ""), appName, MessageBoxButtons.OK);
+
                     return;
                 }
 


### PR DESCRIPTION
- Move the tray icon and relevent code to program.cs
- Change trayicon menu to be a ContextMenuStrip
- Move overlay.run() to a BackgroundWorker
- Call Application.Run() to allow the application to run and not exit immediately after overlay was moved to a BackgroundWorker
- Added mutex to ensure only a single instance of the application is running
- Added more additional context menu items