### PR TITLE
feat: Render config for Unique and Super Unique Monsters

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -42,13 +42,23 @@ RenderingConfiguration:
   Rotate: true
   ZoomLevel: 1
 MapConfiguration:
-  EliteMonster:
+  SuperUniqueMonster:
+    IconColor: Yellow
+    IconShape: SquareOutline
+    IconSize: 6
+    IconThickness: 2
+  UniqueMonster:
     IconColor: DarkOrange
     IconShape: SquareOutline
     IconSize: 6
     IconThickness: 2
-  NormalMonster:
+  EliteMonster:
     IconColor: DarkRed
+    IconShape: SquareOutline
+    IconSize: 6
+    IconThickness: 2
+  NormalMonster:
+    IconColor: Gray
     IconShape: SquareOutline
     IconSize: 6
     IconThickness: 2

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -24,6 +24,7 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using MapAssist.Types;
 using MapAssist.Settings;
+using MapAssist.Structs;
 
 namespace MapAssist.Helpers
 {
@@ -115,7 +116,7 @@ namespace MapAssist.Helpers
 
                 foreach (var unitAny in gameData.Monsters)
                 {
-                    var mobRender = unitAny.IsElite() ? MapAssistConfiguration.Loaded.MapConfiguration.EliteMonster : MapAssistConfiguration.Loaded.MapConfiguration.NormalMonster;
+                    var mobRender = GetMonsterIconRendering(unitAny.MonsterData);
 
                     if (mobRender.CanDrawIcon())
                     {
@@ -162,6 +163,26 @@ namespace MapAssist.Helpers
             }
 
             return (image, localPlayerPosition);
+        }
+
+        private static IconRendering GetMonsterIconRendering(MonsterData monsterData)
+        {
+            if ((monsterData.MonsterType & MonsterTypeFlags.SuperUnique) == MonsterTypeFlags.SuperUnique)
+            {
+                return MapAssistConfiguration.Loaded.MapConfiguration.SuperUniqueMonster;
+            }
+
+            if ((monsterData.MonsterType & MonsterTypeFlags.Unique) == MonsterTypeFlags.Unique)
+            {
+                return MapAssistConfiguration.Loaded.MapConfiguration.UniqueMonster;
+            }
+
+            if (monsterData.MonsterType > 0)
+            {
+                return MapAssistConfiguration.Loaded.MapConfiguration.EliteMonster;
+            }
+
+            return MapAssistConfiguration.Loaded.MapConfiguration.NormalMonster;
         }
 
         private (Bitmap, Point, Point, Point) DrawBackground(AreaData areaData, IReadOnlyList<PointOfInterest> pointOfInterest)

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -97,7 +97,12 @@ namespace MapAssist.Settings
 
     public class MapConfiguration
     {
+        [YamlMember(Alias = "SuperUniqueMonster", ApplyNamingConventions = false)]
+        public IconRendering SuperUniqueMonster { get; set; }
 
+        [YamlMember(Alias = "UniqueMonster", ApplyNamingConventions = false)]
+        public IconRendering UniqueMonster { get; set; }
+        
         [YamlMember(Alias = "EliteMonster", ApplyNamingConventions = false)]
         public IconRendering EliteMonster { get; set; }
 

--- a/Types/UnitAny.cs
+++ b/Types/UnitAny.cs
@@ -191,10 +191,6 @@ namespace MapAssist.Types
             }
         }
 
-        public bool IsElite()
-        {
-            return _monsterData.MonsterType > 0;
-        }
         public bool IsDropped()
         {
             var itemMode = (ItemMode)_unitAny.Mode;


### PR DESCRIPTION
- Extends render config for unique and super unique monsters
- Changes default color scheme for normal monsters

Default color scheme:

- ![#FFFF00](https://via.placeholder.com/15/FFFF00/000000?text=+) SuperUniqueMonster `Yellow` *
- ![#FF8C00](https://via.placeholder.com/15/FF8C00/000000?text=+) UniqueMonster `DarkOrange`
- ![#8B0000](https://via.placeholder.com/15/8B0000/000000?text=+) EliteMonster `DarkRed`
- ![#808080](https://via.placeholder.com/15/808080/000000?text=+)  NormalMonster `Gray`

\* Some _Super Unique Monsters_ have _Unique Monster_ as base type. For example act bosses, The Summoner, ... ([complete List](https://diablo.fandom.com/wiki/Super_Unique_Monsters#Diablo_II_Super_Uniques))

### Screenshots

![image](https://user-images.githubusercontent.com/5048925/144119986-d707b04e-9ccc-4020-b6ed-2f7e3cefa7da.png)

Minions of a rare monster are flagged as ![#8B0000](https://via.placeholder.com/15/8B0000/000000?text=+) `EliteMonster` and the rare monster is flagged as ![#FF8C00](https://via.placeholder.com/15/FF8C00/000000?text=+) `UniqueMonster `

![image](https://user-images.githubusercontent.com/5048925/144121463-fe81535d-eea7-4a7c-beca-3f6924319999.png)

Champion monsters are flagged as ![#FF8C00](https://via.placeholder.com/15/FF8C00/000000?text=+) `UniqueMonster` 

![image](https://user-images.githubusercontent.com/5048925/144120239-a719ac3c-3fd6-41b5-8683-212af51a65ba.png)

Mephisto is flagged as ![#FF8C00](https://via.placeholder.com/15/FF8C00/000000?text=+) `UniqueMonster`. Council members are flagged as ![#FFFF00](https://via.placeholder.com/15/FFFF00/000000?text=+) `SuperUniqueMonster`

