### PR TITLE
Update ItemFilter.yaml, added 0 socket bases to - &player-arm-base

### DIFF
--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -208,6 +208,11 @@ Crusader Gauntlets:
  - Qualities: rare
 Ogre Gauntlets:
  - Qualities: rare
+ 
+### Helmets
+Bone Visage:
+ - Qualities: [normal, superior]
+ - Sockets: [0, 3]
 
 ### Circlets
 Circlet:

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -42,7 +42,7 @@ x-bases:
   Sockets: [0, 3, 4]
  - &player-arm-base
   Qualities: [normal, superior]
-  Sockets: [3, 4]
+  Sockets: [0, 3, 4]
   Ethereal: false
  - &merc-wep-base
   Ethereal: true


### PR DESCRIPTION
We were ignoring 0 socket bases by default, for example +15% defense Superior Archon bases.