### PR TITLE
add NLog logger framework, change console.logs to NLog

### DIFF
--- a/Files/FileManager.cs
+++ b/Files/FileManager.cs
@@ -1,13 +1,13 @@
 ﻿using System.Text;
 using System;
 using System.IO;
-using Newtonsoft.Json;
 using System.Diagnostics;
 
 namespace MapAssist.Files
 {
     public class FileManager
     {
+        private static readonly NLog.Logger _log = NLog.LogManager.GetCurrentClassLogger();
         private string _filePathRelative;
         private string _fullPath;
 
@@ -48,16 +48,16 @@ namespace MapAssist.Files
                 if (FileExists())
                 {
                     System.IO.File.Delete(_fullPath);
-                    Debug.WriteLine($"Removed {_fullPath}");
+                    _log.Debug($"Removed {_fullPath}");
                 }
             }
             catch (Exception e)
             {
-                Debug.WriteLine($"Tried to remove {_fullPath} but got error:\n{e.Message}");
+                _log.Debug(e, $"Tried to remove {_fullPath} but got error.");
             }
         }
 
-        public String ReadFile()
+        public string ReadFile()
         {
             var sb = new StringBuilder();
             try
@@ -75,12 +75,11 @@ namespace MapAssist.Files
             catch (Exception e)
             {
                 // Let the user know what went wrong.
-                Debug.WriteLine($"The file {_filePathRelative} could not be read:");
-                Debug.WriteLine(e.Message);
+                _log.Debug(e, $"The file {_filePathRelative} could not be read.");
             }
             if (sb.ToString().Length == 0)
             {
-                Debug.WriteLine($"The file {_filePathRelative} Was empty ...");
+                _log.Debug($"The file {_filePathRelative} was empty...");
             }
 
             return sb.ToString();
@@ -99,8 +98,7 @@ namespace MapAssist.Files
             catch (Exception e)
             {
                 // Let the user know what went wrong.
-                Debug.WriteLine($"The file {_filePathRelative} could not be written:");
-                Debug.WriteLine(e.Message);
+                _log.Debug(e, $"The file {_filePathRelative} could not be written.");
                 return false;
             }
             return true;

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -19,8 +19,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Media;
 using System.Text;
 using MapAssist.Settings;
 using MapAssist.Types;
@@ -29,6 +27,7 @@ namespace MapAssist.Helpers
 {
     public static class GameMemory
     {
+        private static readonly NLog.Logger _log = NLog.LogManager.GetCurrentClassLogger();
         private static Dictionary<int, uint> _lastMapSeed = new Dictionary<int, uint>();
         private static int _currentProcessId;
         public static GameData GetGameData()
@@ -110,7 +109,14 @@ namespace MapAssist.Helpers
             }
             catch (Exception exception)
             {
-                Console.WriteLine(exception.Message);
+                if (exception.Message == "Game process not found.")
+                {
+                    _log.Debug(exception);
+                }
+                else
+                {
+                    _log.Error(exception);
+                }
                 GameManager.ResetPlayerUnit();
                 return null;
             }

--- a/Helpers/MapApi.cs
+++ b/Helpers/MapApi.cs
@@ -38,6 +38,7 @@ namespace MapAssist.Helpers
     public class MapApi : IDisposable
     {
         public static readonly HttpClient Client = HttpClient(MapAssistConfiguration.Loaded.ApiConfiguration.Endpoint, MapAssistConfiguration.Loaded.ApiConfiguration.Token);
+        private static readonly NLog.Logger _log = NLog.LogManager.GetCurrentClassLogger();
         private readonly string _sessionId;
         private readonly ConcurrentDictionary<Area, AreaData> _cache;
         private readonly BlockingCollection<Area[]> _prefetchRequests;
@@ -86,7 +87,7 @@ namespace MapAssist.Helpers
             if (!_cache.TryGetValue(area, out AreaData areaData))
             {
                 // Not in the cache, block.
-                Console.WriteLine($"Cache miss on {area}");
+                _log.Info($"Cache miss on {area}");
                 areaData = GetMapDataInternal(area);
             }
 
@@ -112,7 +113,7 @@ namespace MapAssist.Helpers
                 // Special value telling us to exit.
                 if (areas.Length == 0)
                 {
-                    Console.WriteLine("Prefetch thread terminating");
+                    _log.Info("Prefetch thread terminating");
                     return;
                 }
 
@@ -121,7 +122,7 @@ namespace MapAssist.Helpers
                     if (_cache.ContainsKey(area)) continue;
 
                     _cache[area] = GetMapDataInternal(area);
-                    Console.WriteLine($"Prefetched {area}");
+                    _log.Info($"Prefetched {area}");
                 }
             }
         }
@@ -166,7 +167,7 @@ namespace MapAssist.Helpers
             }
             catch (HttpRequestException) // Prevent HttpRequestException if D2MapAPI is closed before this program.
             {
-                Console.WriteLine("D2MapAPI server was closed, session was already destroyed.");
+                _log.Info("D2MapAPI server was closed, session was already destroyed.");
             }
         }
 

--- a/Helpers/ProcessContext.cs
+++ b/Helpers/ProcessContext.cs
@@ -26,6 +26,7 @@ namespace MapAssist.Helpers
     public class ProcessContext : IDisposable
     {
         public int OpenContextCount = 1;
+        private static readonly NLog.Logger _log = NLog.LogManager.GetCurrentClassLogger();
         private Process _process;
         private IntPtr _handle;
         private IntPtr _baseAddr;
@@ -123,7 +124,7 @@ namespace MapAssist.Helpers
             var resultRelativeAddress = IntPtr.Add(patternAddress, 3);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                Console.WriteLine("We failed to read the process memory");
+                _log.Info("We failed to read the process memory");
                 return IntPtr.Zero;
             }
 
@@ -141,7 +142,7 @@ namespace MapAssist.Helpers
             var resultRelativeAddress = IntPtr.Add(patternAddress, 6);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                Console.WriteLine("We failed to read the process memory");
+                _log.Info("We failed to read the process memory");
                 return IntPtr.Zero;
             }
 
@@ -160,7 +161,7 @@ namespace MapAssist.Helpers
             var resultRelativeAddress = IntPtr.Add(patternAddress, -4);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                Console.WriteLine("We failed to read the process memory");
+                _log.Info("We failed to read the process memory");
                 return IntPtr.Zero;
             }
 
@@ -178,7 +179,7 @@ namespace MapAssist.Helpers
             var resultRelativeAddress = IntPtr.Add(patternAddress, 3);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                Console.WriteLine("We failed to read the process memory");
+                _log.Info("We failed to read the process memory");
                 return IntPtr.Zero;
             }
 
@@ -216,7 +217,7 @@ namespace MapAssist.Helpers
             var memoryBuffer = new byte[_moduleSize];
             if (WindowsExternal.ReadProcessMemory(_handle, _baseAddr, memoryBuffer, _moduleSize, out _) == false)
             {
-                Console.WriteLine("We failed to read the process memory");
+                _log.Info("We failed to read the process memory");
                 return null;
             }
 

--- a/MapAssist.csproj
+++ b/MapAssist.csproj
@@ -191,6 +191,9 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>
+    <PackageReference Include="NLog">
+      <Version>4.7.12</Version>
+    </PackageReference>
     <PackageReference Include="YamlDotNet">
       <Version>11.2.1</Version>
     </PackageReference>


### PR DESCRIPTION
- adds NLog as logging framework
- retains default Console-Logger for all messages, from Debug to Fatal
- adds rolling File-Logger, files are put in folder /logs, timestamped and indexed per run of the overlay, for LogLevels Info to Fatal
- this should allow for better bug reports from users