### PR TITLE
Minor fix for Icon size

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -323,10 +323,10 @@ namespace MapAssist.Helpers
             if (!_iconCache.ContainsKey(cacheKey))
             {
                 var distort = poiSettings.IconShape == Shape.Cross ? true : false;
-                var width = poiSettings.IconSize * scaleWidth + poiSettings.IconThickness;
-                var height = poiSettings.IconSize * (distort ? scaleHeight : scaleWidth) + poiSettings.IconThickness;
-
-                var bitmap = new Bitmap((int)width, (int)height, PixelFormat.Format32bppArgb);
+                var width = (int)Math.Ceiling(poiSettings.IconSize * scaleWidth + poiSettings.IconThickness);
+                var height = (int)Math.Ceiling(poiSettings.IconSize * (distort ? scaleHeight : scaleWidth) + poiSettings.IconThickness);
+                
+                var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
                 var pen = new Pen(poiSettings.IconColor, poiSettings.IconThickness);
                 var brush = new SolidBrush(poiSettings.IconColor);
                 using (var g = Graphics.FromImage(bitmap))
@@ -367,18 +367,17 @@ namespace MapAssist.Helpers
                             g.FillPolygon(brush, curvePoints);
                             break;
                         case Shape.Cross:
-                            var a = poiSettings.IconSize * 0.00f;
-                            var b = poiSettings.IconSize * 0.25f;
-                            var c = poiSettings.IconSize * 0.50f;
-                            var d = poiSettings.IconSize * 0.75f;
-                            var e = poiSettings.IconSize * 1.00f;
+                            var a = poiSettings.IconSize * 0.25f;
+                            var b = poiSettings.IconSize * 0.50f;
+                            var c = poiSettings.IconSize * 0.75f;
+                            var d = poiSettings.IconSize;
+
                             PointF[] crossLinePoints =
                             {
-                                new PointF(0, b), new PointF(b, a), new PointF(c, b), new PointF(d, a),
-                                new PointF(e, b), new PointF(d, c), new PointF(e, d), new PointF(d, e),
-                                new PointF(c, d), new PointF(b, e), new PointF(a, d), new PointF(b, c),
-                                new PointF(a, b),
-
+                                new PointF(0, a), new PointF(a, 0), new PointF(b, a), new PointF(c, 0),
+                                new PointF(d, a), new PointF(c, b), new PointF(d, c), new PointF(c, d),
+                                new PointF(b, c), new PointF(a, d), new PointF(0, c), new PointF(a, b),
+                                new PointF(0, a),
                             };
 
                             for (var i = 0; i < crossLinePoints.Length; i++)

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -325,7 +325,7 @@ namespace MapAssist.Helpers
                 var distort = poiSettings.IconShape == Shape.Cross ? true : false;
                 var width = (int)Math.Ceiling(poiSettings.IconSize * scaleWidth + poiSettings.IconThickness);
                 var height = (int)Math.Ceiling(poiSettings.IconSize * (distort ? scaleHeight : scaleWidth) + poiSettings.IconThickness);
-                
+
                 var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
                 var pen = new Pen(poiSettings.IconColor, poiSettings.IconThickness);
                 var brush = new SolidBrush(poiSettings.IconColor);


### PR DESCRIPTION
This is a minor fix to use `Math.Ceiling()` when converting width/height float values to integer.  

When casting these floats to integer with `(int)` the decimals are dropped which causes some pixels to be cut off the bottom & right side of the icon bitmap.  This is noticeable in the `Cross` icon shape.

Before:
![overlay_before](https://user-images.githubusercontent.com/10291543/144168193-3ffd4b9a-abba-42af-bc14-5c515a039059.png)
![nonoverlay_before](https://user-images.githubusercontent.com/10291543/144168210-25446b14-07af-463b-9d03-be20734ace88.png)

After:
![overlay_after](https://user-images.githubusercontent.com/10291543/144168220-9c963396-c1d2-4a0f-8dfd-7c4fa23d53f9.png)
![nonoverlay_after](https://user-images.githubusercontent.com/10291543/144168226-ae554791-9e15-4874-82c8-eb980ad5ee26.png)
