### PR TITLE
Configuration for rendering GameInfo (Game IP) and hotkey to toggle

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -137,13 +137,14 @@ HotkeyConfiguration:
   ToggleKey: '\'
   ZoomInKey: '+'
   ZoomOutKey: '-'
+  GameInfoKey: '['
 ApiConfiguration:
   Endpoint: 'http://localhost:8080/'
   Token: ''
 GameInfo:
+  Enabled: true
   # Developer setting, probably not useful
   ShowOverlayFPS: false
-  AlwaysShow: true
 ItemLog:
   FilterFileName: "ItemFilter.yaml"
   PlaySoundOnDrop: true

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -223,22 +223,25 @@ namespace MapAssist
             var fontHeight = (fontSize + fontSize / 2);
 
             // Game IP
-            gfx.DrawText(_fonts["consolas"], _brushes["red"], textXOffset, textYOffset,
-                "Game IP: " + _currentGameData.GameIP);
-            textYOffset += fontHeight + 5;
-
-            // Overlay FPS
-            if (MapAssistConfiguration.Loaded.GameInfo.ShowOverlayFPS)
+            if (MapAssistConfiguration.Loaded.GameInfo.Enabled)
             {
-                var padding = 16;
-                var infoText = new System.Text.StringBuilder()
-                    .Append("FPS: ").Append(gfx.FPS.ToString().PadRight(padding))
-                    .Append("DeltaTime: ").Append(renderDeltaText.PadRight(padding))
-                    .ToString();
+                gfx.DrawText(_fonts["consolas"], _brushes["red"], textXOffset, textYOffset,
+                    "Game IP: " + _currentGameData.GameIP);
+                textYOffset += fontHeight + 5;
 
-                gfx.DrawText(_fonts["consolas"], _brushes["green"], textXOffset, textYOffset, infoText);
+                // Overlay FPS
+                if (MapAssistConfiguration.Loaded.GameInfo.ShowOverlayFPS)
+                {
+                    var padding = 16;
+                    var infoText = new System.Text.StringBuilder()
+                        .Append("FPS: ").Append(gfx.FPS.ToString().PadRight(padding))
+                        .Append("DeltaTime: ").Append(renderDeltaText.PadRight(padding))
+                        .ToString();
 
-                textYOffset += fontHeight;
+                    gfx.DrawText(_fonts["consolas"], _brushes["green"], textXOffset, textYOffset, infoText);
+
+                    textYOffset += fontHeight;
+                }
             }
 
             // Item log
@@ -345,6 +348,11 @@ namespace MapAssist
                         MapAssistConfiguration.Loaded.RenderingConfiguration.Size =
                             (int)(MapAssistConfiguration.Loaded.RenderingConfiguration.Size * .85f);
                     }
+                }
+
+                if (args.KeyChar == MapAssistConfiguration.Loaded.HotkeyConfiguration.GameInfoKey)
+                {
+                    MapAssistConfiguration.Loaded.GameInfo.Enabled = !MapAssistConfiguration.Loaded.GameInfo.Enabled;
                 }
             }
         }

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -178,6 +178,9 @@ public class HotkeyConfiguration
 
     [YamlMember(Alias = "ZoomOutKey", ApplyNamingConventions = false)]
     public char ZoomOutKey { get; set; }
+
+    [YamlMember(Alias = "GameInfoKey", ApplyNamingConventions = false)]
+    public char GameInfoKey { get; set; }
 }
 
 public class ApiConfiguration
@@ -191,8 +194,8 @@ public class ApiConfiguration
 
 public class GameInfoConfiguration
 {
-    [YamlMember(Alias = "AlwaysShow", ApplyNamingConventions = false)]
-    public bool AlwaysShow { get; set; }
+    [YamlMember(Alias = "Enabled", ApplyNamingConventions = false)]
+    public bool Enabled { get; set; }
     
     [YamlMember(Alias = "ShowOverlayFPS", ApplyNamingConventions = false)]
     public bool ShowOverlayFPS { get; set; }


### PR DESCRIPTION
Added `GameInfo.Enabled` flag for easily turning Game IP rendering off

Added `HotkeyConfiguration.GameInfoKey` for quickly changing the setting in-game

Removed `GameInfo.AlwaysShow` as it doesn't appear to be hooked up to anything