### PR TITLE
Bug fix for crash when using `ItemLog.Enabled: false`

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -169,23 +169,26 @@ namespace MapAssist.Helpers
                     }
                 }
 
-                var font = new Font(MapAssistConfiguration.Loaded.MapConfiguration.Item.LabelFont, MapAssistConfiguration.Loaded.MapConfiguration.Item.LabelFontSize);
-                foreach (var item in gameData.Items)
+                if (MapAssistConfiguration.Loaded.ItemLog.Enabled)
                 {
-                    if (item.IsDropped())
+                    var font = new Font(MapAssistConfiguration.Loaded.MapConfiguration.Item.LabelFont, MapAssistConfiguration.Loaded.MapConfiguration.Item.LabelFontSize);
+                    foreach (var item in gameData.Items)
                     {
-                        if (!LootFilter.Filter(item))
+                        if (item.IsDropped())
                         {
-                            continue;
+                            if (!LootFilter.Filter(item))
+                            {
+                                continue;
+                            }
+                            var color = Items.ItemColors[item.ItemData.ItemQuality];
+                            Bitmap icon = GetIcon(MapAssistConfiguration.Loaded.MapConfiguration.Item);
+                            var itemPosition = adjustedPoint(item.Position).OffsetFrom(GetIconOffset(MapAssistConfiguration.Loaded.MapConfiguration.Item));
+                            imageGraphics.DrawImage(icon, itemPosition);
+                            var itemBaseName = Items.ItemNames[item.TxtFileNo];
+                            imageGraphics.DrawString(itemBaseName, font,
+                                new SolidBrush(color),
+                                itemPosition.OffsetFrom(new Point(-icon.Width - 5, 0)));
                         }
-                        var color = Items.ItemColors[item.ItemData.ItemQuality];
-                        Bitmap icon = GetIcon(MapAssistConfiguration.Loaded.MapConfiguration.Item);
-                        var itemPosition = adjustedPoint(item.Position).OffsetFrom(GetIconOffset(MapAssistConfiguration.Loaded.MapConfiguration.Item));
-                        imageGraphics.DrawImage(icon, itemPosition);
-                        var itemBaseName = Items.ItemNames[item.TxtFileNo];
-                        imageGraphics.DrawString(itemBaseName, font,
-                            new SolidBrush(color),
-                            itemPosition.OffsetFrom(new Point(-icon.Width - 5, 0)));
                     }
                 }
             }


### PR DESCRIPTION
Steps to repro:
* Set `ItemLog.Enabled = false` in config
* Find or just throw a flawless gem on the ground
* Error is thrown
![bugfix](https://user-images.githubusercontent.com/10291543/144764462-bb0a77b3-2ee1-4f6a-9d70-0dd9e35a7e85.png)

The error happens when Compose attempts to draw items in the loot filter. 

Wrapping the items drawing with an `if (ItemLog.Enabled)` prevents the error.