### PR TITLE
Different images for different item types.

### DIFF
--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -25,7 +25,7 @@ namespace MapAssist.Helpers
 {
     public static class LootFilter
     {
-        public static bool Filter(UnitAny unitAny)
+        public static ItemFilter Filter(UnitAny unitAny)
         {
             var baseName = Items.ItemName(unitAny.TxtFileNo);
             var itemQuality = unitAny.ItemData.ItemQuality;
@@ -40,12 +40,12 @@ namespace MapAssist.Helpers
             return Filter(baseName, itemQuality, isEth, numSockets, lowQuality);
         }
 
-        private static bool Filter(string baseName, ItemQuality itemQuality, bool isEth, int numSockets,
+        private static ItemFilter Filter(string baseName, ItemQuality itemQuality, bool isEth, int numSockets,
             bool lowQuality)
         {
             if (lowQuality)
             {
-                return false;
+                return null;
             }
 
             //populate a list of filter rules by combining rules from "Any" and the item base name
@@ -59,7 +59,7 @@ namespace MapAssist.Helpers
             // So we know that simply having the name match means we can return true
             if (matches.Any(kv => kv.Value == null))
             {
-                return true;
+                return new ItemFilter();
             }
 
             //scan the list of rules
@@ -71,10 +71,10 @@ namespace MapAssist.Helpers
                                    item.Sockets.Contains(numSockets);
 
                 var ethReqMet = (item.Ethereal == null || item.Ethereal == isEth);
-                if (qualityReqMet && socketReqMet && ethReqMet) { return true; }
+                if (qualityReqMet && socketReqMet && ethReqMet) { return item; }
             }
 
-            return false;
+            return null;
         }
     }
 }

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -20,5 +20,6 @@ namespace MapAssist.Settings
         public ItemQuality[] Qualities { get; set; }
         public bool? Ethereal { get; set; }
         public int[] Sockets { get; set; }
+        public string Icon { get; set; }
     }
 }

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -210,4 +210,10 @@ public class ItemLogConfiguration
 
     [YamlMember(Alias = "LabelFontSize", ApplyNamingConventions = false)]
     public int LabelFontSize { get; set; }
+
+    [YamlMember(Alias = "DefaultIcon", ApplyNamingConventions = false)]
+    public string DefaultIcon { get; set; }
+
+    [YamlMember(Alias = "MaxIconSize", ApplyNamingConventions = false)]
+    public int MaxIconSize { get; set; }
 }

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -187,7 +187,7 @@ namespace MapAssist.Types
         public static void LogItem(UnitAny unit, int processId)
         {
             if ((!ItemUnitHashesSeen[processId].Contains(unit.ItemHash()) &&
-                 !ItemUnitIdsSeen[processId].Contains(unit.UnitId)) && LootFilter.Filter(unit))
+                 !ItemUnitIdsSeen[processId].Contains(unit.UnitId)) && LootFilter.Filter(unit) != null)
             {
                 if (MapAssistConfiguration.Loaded.ItemLog.PlaySoundOnDrop)
                 {


### PR DESCRIPTION
Add feature to show different images for different items.
By default the behavior is no change. The shape specified in
MapConfiguration.Item will be shown.

If user specify icon path in these places:
1. ItemFilter.yaml: Add an Icon entry for some item type
```yaml
    Grand Charm:
      - Icon: "gc.png"
```
2. ItemLog: Add entry DefaultIcon

The icon image will be shown.

By default the image will be shown as its original size;
user can set MaxIconSize to control its maximum size.