### PR TITLE
Rendering Improvements

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -34,7 +34,7 @@ RenderingConfiguration:
   ToggleViaInGamePanels: false
   ## Size - Overlay map maximum size
   Size: 450
-  ## Rotate - Transform map image with 45° rotation
+  ## Rotate - Transform map image with 45 degree rotation
   Rotate: true
   ## ZoomLevel - Zoom level / can zoom in/out with hotkeys (ZoomInKey, ZoomOutKey)
   ZoomLevel: 1
@@ -47,67 +47,67 @@ RenderingConfiguration:
 MapConfiguration:
   SuperUniqueMonster:
     IconColor: Yellow
-    IconShape: SquareOutline
+    IconShape: Cross
     IconSize: 6
     IconThickness: 2
   UniqueMonster:
     IconColor: DarkOrange
-    IconShape: SquareOutline
+    IconShape: Cross
     IconSize: 6
     IconThickness: 2
   EliteMonster:
     IconColor: DarkRed
-    IconShape: SquareOutline
+    IconShape: Cross
     IconSize: 6
     IconThickness: 2
   NormalMonster:
     IconColor: Gray
-    IconShape: SquareOutline
+    IconShape: Cross
     IconSize: 6
     IconThickness: 2
   NextArea:
     IconColor: '237, 107, 0'
     IconShape: Square
-    IconSize: 10
+    IconSize: 4
     LineColor: Chartreuse
     LineThickness: 2
-    ArrowHeadSize: 10
+    ArrowHeadSize: 5
     LabelColor: Chartreuse
-    LabelFontSize: 8
+    LabelFontSize: 12
     LabelFont: 'Helvetica'
   PreviousArea:
     IconColor: '255, 0, 149'
     IconShape: Square
-    IconSize: 10
+    IconSize: 4
     LineColor: ''
     LabelColor: Chartreuse
-    LabelFontSize: 8
+    LabelFontSize: 12
     LabelFont: 'Helvetica'
   Waypoint:
     IconColor: '16, 140, 235'
     IconShape: Square
-    IconSize: 10
+    IconSize: 6
   Quest:
     LineColor: Chartreuse
     LineThickness: 2
     ArrowHeadSize: 5
   Player:
     IconColor: '255, 255, 0'
-    IconShape: Square
-    IconSize: 5
+    IconShape: Cross
+    IconSize: 6
     IconThickness: 2
   SuperChest:
     IconColor: '17, 255, 0'
-    IconShape: Ellipse
-    IconSize: 10
+    IconShape: Square
+    IconSize: 4
   NormalChest:
     IconColor: '96, 96, 96'
     IconShape: Square
-    IconSize: 5
+    IconSize: 3
   Shrine:
     IconColor: '255, 218, 100'
     IconShape: Polygon
-    IconSize: 10
+    IconSize: 5
   ArmorWeapRack:
     IconColor: '132, 132, 132'
     IconShape: Square
@@ -115,9 +115,9 @@ MapConfiguration:
   Item: 
     IconColor: 'DarkOrange'
     IconShape: Ellipse
-    IconSize: 6
+    IconSize: 4
     LabelFont: 'Helvetica'
-    LabelFontSize: 8
+    LabelFontSize: 12
 
 ## ItemLog - Alerts for in-game dropped items nearby
 ItemLog:

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -25,15 +25,16 @@ using System.Drawing.Imaging;
 using MapAssist.Types;
 using MapAssist.Settings;
 using MapAssist.Structs;
+using System.Linq;
 
 namespace MapAssist.Helpers
 {
     public class Compositor
     {
         private readonly AreaData _areaData;
-        private readonly Point _cropOffset;
-        private readonly Point _origCenter;
-        private readonly Point _rotatedCenter;
+        private readonly PointF _cropOffset;
+        private readonly PointF _origCenter;
+        private readonly PointF _rotatedCenter;
         private readonly IReadOnlyList<PointOfInterest> _pointsOfInterest;
         private readonly Dictionary<(string, int), Font> _fontCache = new Dictionary<(string, int), Font>();
         private readonly int _rotateDegrees = 45;
@@ -54,7 +55,7 @@ namespace MapAssist.Helpers
             (background, _cropOffset, _origCenter, _rotatedCenter) = DrawBackground(areaData, pointsOfInterest);
         }
 
-        public (Bitmap, Point) Compose(GameData gameData, float zoomLevel)
+        public (Bitmap, PointF) Compose(GameData gameData)
         {
             if (gameData.Area != _areaData.Area)
             {
@@ -79,39 +80,52 @@ namespace MapAssist.Helpers
                 image = (Bitmap)scaledBackground.Clone();
             }
 
-            var localPlayerPosition = adjustedPoint(gameData.PlayerPosition);
+            var localPlayerPosition = AdjustedPoint(gameData.PlayerPosition);
 
-            using (var imageGraphics = Graphics.FromImage(image))
+            using (var gfx = Graphics.FromImage(image))
             {
-                imageGraphics.CompositingQuality = CompositingQuality.HighQuality;
-                imageGraphics.InterpolationMode = InterpolationMode.Bicubic;
-                imageGraphics.SmoothingMode = SmoothingMode.HighQuality;
-                imageGraphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                gfx.CompositingQuality = CompositingQuality.HighQuality;
+                gfx.InterpolationMode = InterpolationMode.Bicubic;
+                gfx.SmoothingMode = SmoothingMode.HighQuality;
+                gfx.PixelOffsetMode = PixelOffsetMode.HighQuality;
 
-                if (MapAssistConfiguration.Loaded.MapConfiguration.Player.CanDrawIcon())
-                {
-                    Bitmap playerIcon = GetIcon(MapAssistConfiguration.Loaded.MapConfiguration.Player);
-                    var playerPosition = localPlayerPosition.OffsetFrom(GetIconOffset(MapAssistConfiguration.Loaded.MapConfiguration.Player));
-                    imageGraphics.DrawImage(playerIcon, playerPosition);
-                }
-
-                // The lines are dynamic, and follow the player, so have to be drawn here.
-                // The rest can be done in DrawBackground.
                 foreach (PointOfInterest poi in _pointsOfInterest)
                 {
+                    var poiIcon = GetIcon(poi.RenderingSettings);
+                    var poiPosition = AdjustedPoint(poi.Position);
+
+                    if (poi.RenderingSettings.CanDrawIcon())
+                    {
+                        gfx.DrawImage(poiIcon, poiPosition.OffsetFrom(GetIconOffset(poi.RenderingSettings)));
+                    }
+
                     if (poi.RenderingSettings.CanDrawLine())
                     {
                         var pen = new Pen(poi.RenderingSettings.LineColor, poi.RenderingSettings.LineThickness);
+
                         if (poi.RenderingSettings.CanDrawArrowHead())
                         {
-                            pen.CustomEndCap = new AdjustableArrowCap(poi.RenderingSettings.ArrowHeadSize,
-                                poi.RenderingSettings.ArrowHeadSize);
+                            pen.CustomEndCap = new AdjustableArrowCap(poi.RenderingSettings.ArrowHeadSize, poi.RenderingSettings.ArrowHeadSize);
                         }
 
-                        var poiPosition = adjustedPoint(poi.Position);
-
-                        imageGraphics.DrawLine(pen, localPlayerPosition, poiPosition);
+                        gfx.DrawLine(pen, localPlayerPosition, poiPosition);
                     }
+
+                    if (!string.IsNullOrWhiteSpace(poi.Label) && poi.RenderingSettings.CanDrawLabel())
+                    {
+                        var poiFont = GetFont(poi.RenderingSettings);
+
+                        var stringSize = gfx.MeasureString(poi.Label, poiFont);
+
+                        gfx.DrawString(poi.Label, poiFont, new SolidBrush(poi.RenderingSettings.LabelColor), poiPosition.OffsetFrom(stringSize.Center()).OffsetFrom(new PointF(0, poiIcon.Height)));
+                    }
+                }
+
+                if (MapAssistConfiguration.Loaded.MapConfiguration.Player.CanDrawIcon())
+                {
+                    var playerIcon = GetIcon(MapAssistConfiguration.Loaded.MapConfiguration.Player);
+                    var playerPosition = localPlayerPosition.OffsetFrom(GetIconOffset(MapAssistConfiguration.Loaded.MapConfiguration.Player));
+                    gfx.DrawImage(playerIcon, playerPosition);
                 }
 
                 var monsterRenderingOrder = new IconRendering[]
@@ -128,10 +142,10 @@ namespace MapAssist.Helpers
                     {
                         if (mobRender == GetMonsterIconRendering(unitAny.MonsterData) && mobRender.CanDrawIcon())
                         {
-                            Bitmap icon = GetIcon(mobRender);
-                            var monsterPosition = adjustedPoint(unitAny.Position).OffsetFrom(GetIconOffset(mobRender));
+                            var icon = GetIcon(mobRender);
+                            var monsterPosition = AdjustedPoint(unitAny.Position).OffsetFrom(GetIconOffset(mobRender));
 
-                            imageGraphics.DrawImage(icon, monsterPosition);
+                            gfx.DrawImage(icon, monsterPosition);
                         }
                     }
                 }
@@ -142,26 +156,26 @@ namespace MapAssist.Helpers
                     {
                         if (mobRender == GetMonsterIconRendering(unitAny.MonsterData) && mobRender.CanDrawIcon())
                         {
-                            Bitmap icon = GetIcon(mobRender);
-                            var monsterPosition = adjustedPoint(unitAny.Position).OffsetFrom(GetIconOffset(mobRender));
+                            var icon = GetIcon(mobRender);
+                            var monsterPosition = AdjustedPoint(unitAny.Position).OffsetFrom(GetIconOffset(mobRender));
 
                             // Draw Monster Immunities on top of monster icon
                             var iCount = unitAny.Immunities.Count;
                             if (iCount > 0)
                             {
-                                var rectSize = mobRender.IconSize / 3; // Arbirarily made the size set to 1/3rd of the mob icon size. The import point is that it scales with the mob icon consistently.
-                                var dx = rectSize * scaleWidth * 1.5; // Amount of space each indicator will take up, including spacing (which is the 1.5)
+                                var rectSize = mobRender.IconSize / 4f; // Arbirarily made the size set to 1/4rd of the mob icon size. The import point is that it scales with the mob icon consistently.
+                                var dx = rectSize * scaleWidth * 1.5f; // Amount of space each indicator will take up, including spacing (which is the 1.5)
 
                                 var iX = -icon.Width / 2f // Start at the center of the mob icon
-                                    + (rectSize * scaleWidth) / 2 // Make sure the center of the indicator lines up with the center of the mob icon
-                                    - dx * (iCount - 1) / 2; // Moves the first indicator sufficiently left so that the whole group of indicators will be centered.
+                                    + (rectSize * scaleWidth) / 2f // Make sure the center of the indicator lines up with the center of the mob icon
+                                    - dx * (iCount - 1) / 2f; // Moves the first indicator sufficiently left so that the whole group of indicators will be centered.
 
                                 foreach (var immunity in unitAny.Immunities)
                                 {
-                                    var iPoint = new Point((int)Math.Round(iX), icon.Height / 2 + icon.Height / 12); // 1/12th of the height just helps move the icon a bit up to make it look nicer. Purely arbitrary.
+                                    var iPoint = new PointF(iX, icon.Height / 2f - icon.Height / 6f); // 1/6th of the height just helps move the icon a bit vertically to make it look nicer. Purely arbitrary.
                                     var brush = new SolidBrush(ResistColors.ResistColor[immunity]);
-                                    var rect = new Rectangle(monsterPosition.OffsetFrom(iPoint), new Size((int)(rectSize * scaleWidth), (int)(rectSize * scaleWidth))); // Scale both by the width since width isn't impacted by depth in overlay mode
-                                    imageGraphics.FillEllipse(brush, rect);
+                                    var rect = new Rectangle(monsterPosition.OffsetFrom(iPoint).ToPoint(), new SizeF(rectSize * scaleWidth, rectSize * scaleWidth).ToSize()); // Scale both by the width since width isn't impacted by depth in overlay mode
+                                    gfx.FillEllipse(brush, rect);
                                     iX += dx;
                                 }
                             }
@@ -181,13 +195,14 @@ namespace MapAssist.Helpers
                                 continue;
                             }
                             var color = Items.ItemColors[item.ItemData.ItemQuality];
-                            Bitmap icon = GetIcon(MapAssistConfiguration.Loaded.MapConfiguration.Item);
-                            var itemPosition = adjustedPoint(item.Position).OffsetFrom(GetIconOffset(MapAssistConfiguration.Loaded.MapConfiguration.Item));
-                            imageGraphics.DrawImage(icon, itemPosition);
+                            var icon = GetIcon(MapAssistConfiguration.Loaded.MapConfiguration.Item);
+                            var itemPosition = AdjustedPoint(item.Position);
                             var itemBaseName = Items.ItemNames[item.TxtFileNo];
-                            imageGraphics.DrawString(itemBaseName, font,
-                                new SolidBrush(color),
-                                itemPosition.OffsetFrom(new Point(-icon.Width - 5, 0)));
+
+                            var stringSize = gfx.MeasureString(itemBaseName, font);
+
+                            gfx.DrawImage(icon, itemPosition.OffsetFrom(GetIconOffset(MapAssistConfiguration.Loaded.MapConfiguration.Item)));
+                            gfx.DrawString(itemBaseName, font, new SolidBrush(color), itemPosition.OffsetFrom(stringSize.Center()).OffsetFrom(new Point(0, icon.Height)));
                         }
                     }
                 }
@@ -216,81 +231,54 @@ namespace MapAssist.Helpers
             return MapAssistConfiguration.Loaded.MapConfiguration.NormalMonster;
         }
 
-        private (Bitmap, Point, Point, Point) DrawBackground(AreaData areaData, IReadOnlyList<PointOfInterest> pointOfInterest)
+        private (Bitmap, PointF, PointF, PointF) DrawBackground(AreaData areaData, IReadOnlyList<PointOfInterest> pointOfInterest)
         {
-            var background = new Bitmap(areaData.CollisionGrid[0].Length, areaData.CollisionGrid.Length,
-                PixelFormat.Format32bppArgb);
-            using (var backgroundGraphics = Graphics.FromImage(background))
+            var padding = 10;
+            background = new Bitmap(areaData.CollisionGrid[0].Length, areaData.CollisionGrid.Length, PixelFormat.Format32bppArgb);
+            using (var gfx = Graphics.FromImage(background))
             {
-                backgroundGraphics.FillRectangle(new SolidBrush(Color.Transparent), 0, 0,
-                    areaData.CollisionGrid[0].Length,
-                    areaData.CollisionGrid.Length);
-                backgroundGraphics.CompositingQuality = CompositingQuality.HighQuality;
-                backgroundGraphics.InterpolationMode = InterpolationMode.Bicubic;
-                backgroundGraphics.SmoothingMode = SmoothingMode.HighQuality;
-                backgroundGraphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                gfx.CompositingQuality = CompositingQuality.HighQuality;
+                gfx.InterpolationMode = InterpolationMode.Bicubic;
+                gfx.SmoothingMode = SmoothingMode.HighQuality;
+                gfx.PixelOffsetMode = PixelOffsetMode.HighQuality;
 
                 for (var y = 0; y < areaData.CollisionGrid.Length; y++)
                 {
                     for (var x = 0; x < areaData.CollisionGrid[y].Length; x++)
                     {
                         var type = areaData.CollisionGrid[y][x];
-                        Color? typeColor = MapAssistConfiguration.Loaded.MapColorConfiguration.LookupMapColor(type);
+                        var typeColor = MapAssistConfiguration.Loaded.MapColorConfiguration.LookupMapColor(type);
                         if (typeColor != null)
                         {
                             background.SetPixel(x, y, (Color)typeColor);
                         }
                     }
                 }
-
-                foreach (PointOfInterest poi in pointOfInterest)
-                {
-                    if (poi.RenderingSettings.CanDrawIcon())
-                    {
-                        Bitmap icon = GetIcon(poi.RenderingSettings);
-                        Point origin = poi.Position
-                            .OffsetFrom(areaData.Origin)
-                            .OffsetFrom(GetIconOffset(poi.RenderingSettings));
-                        backgroundGraphics.DrawImage(icon, origin);
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(poi.Label) && poi.RenderingSettings.CanDrawLabel())
-                    {
-                        Font font = GetFont(poi.RenderingSettings);
-                        backgroundGraphics.DrawString(poi.Label, font,
-                            new SolidBrush(poi.RenderingSettings.LabelColor),
-                            poi.Position.OffsetFrom(areaData.Origin));
-                    }
-                }
-
-                var center = new Point(background.Width / 2, background.Height / 2);
-
-                background = ImageUtils.RotateImage(background, _rotateDegrees, true, false, Color.Transparent);
-                var rotatedCenter = new Point(background.Width / 2, background.Height / 2);
-
-                var (newBackground, cropOffset) = ImageUtils.CropBitmap(background);
-
-                return (newBackground, cropOffset, center, rotatedCenter);
             }
+
+            var center = new PointF(background.Width / 2f, background.Height / 2f);
+
+            background = ImageUtils.RotateImage(background, _rotateDegrees, true, false, Color.Transparent);
+            var rotatedCenter = new PointF(background.Width / 2f, background.Height / 2f);
+
+            var (newBackground, cropOffset) = ImageUtils.CropBitmap(background, padding);
+
+            return (newBackground, cropOffset, center, rotatedCenter);
         }
 
-        private Point adjustedPoint(Point p)
+        private PointF AdjustedPoint(PointF p)
         {
-            p = ImageUtils.RotatePoint(p.OffsetFrom(_areaData.Origin), _origCenter, _rotateDegrees)
+            var newP = p.OffsetFrom(_areaData.Origin).Rotate(_rotateDegrees, _origCenter)
                 .OffsetFrom(_origCenter.OffsetFrom(_rotatedCenter))
-                .OffsetFrom(_cropOffset);
+                .OffsetFrom(_cropOffset)
+                .Multiply(scaleWidth, scaleHeight);
 
-            p = new Point(
-                (int)(p.X * scaleWidth),
-                (int)(p.Y * scaleHeight)
-            );
-
-            return p;
+            return newP;
         }
 
         private (float, float) CalcResizeRatios(Bitmap image)
         {
-            var multiplier = 4.25f - MapAssistConfiguration.Loaded.RenderingConfiguration.ZoomLevel; // Hitting +/- should make the map bigger/smaller, respectively, like in overlay = false mode
+            var multiplier = 5.5f - MapAssistConfiguration.Loaded.RenderingConfiguration.ZoomLevel; // Hitting +/- should make the map bigger/smaller, respectively, like in overlay = false mode
 
             if (!MapAssistConfiguration.Loaded.RenderingConfiguration.OverlayMode)
             {
@@ -303,12 +291,17 @@ namespace MapAssist.Helpers
                     multiplier = 1;
                 }
             }
+            else if (MapAssistConfiguration.Loaded.RenderingConfiguration.Position != MapPosition.Center)
+            {
+                multiplier *= 0.5f;
+            }
 
             if (multiplier != 1 || MapAssistConfiguration.Loaded.RenderingConfiguration.OverlayMode)
             {
                 var heightShrink = MapAssistConfiguration.Loaded.RenderingConfiguration.OverlayMode ? 0.5f : 1f;
+                var widthShrink = MapAssistConfiguration.Loaded.RenderingConfiguration.OverlayMode ? 1f : 1f;
 
-                return (multiplier, multiplier * heightShrink);
+                return (multiplier * widthShrink, multiplier * heightShrink);
             }
 
             return (multiplier, multiplier);
@@ -338,76 +331,98 @@ namespace MapAssist.Helpers
             );
             if (!_iconCache.ContainsKey(cacheKey))
             {
-                var distort = poiSettings.IconShape == Shape.Cross ? true : false;
-                var width = (int)Math.Ceiling(poiSettings.IconSize * scaleWidth + poiSettings.IconThickness);
-                var height = (int)Math.Ceiling(poiSettings.IconSize * (distort ? scaleHeight : scaleWidth) + poiSettings.IconThickness);
-
-                var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+                var iconPadding = 5; // Some extra padding to make sure nothing get trimmed
+                Bitmap bitmap = null;
                 var pen = new Pen(poiSettings.IconColor, poiSettings.IconThickness);
                 var brush = new SolidBrush(poiSettings.IconColor);
-                using (var g = Graphics.FromImage(bitmap))
+                
+                switch (poiSettings.IconShape)
                 {
-                    g.SmoothingMode = SmoothingMode.HighQuality;
-                    switch (poiSettings.IconShape)
-                    {
-                        case Shape.Ellipse:
-                            g.FillEllipse(brush, 0, 0, poiSettings.IconSize * scaleWidth, poiSettings.IconSize * scaleWidth);
-                            break;
-                        case Shape.EllipseOutline:
-                            g.DrawEllipse(pen, 0, 0, poiSettings.IconSize * scaleWidth, poiSettings.IconSize * scaleWidth);
-                            break;
-                        case Shape.Square:
-                            g.FillRectangle(brush, 0, 0, poiSettings.IconSize * scaleWidth, poiSettings.IconSize * scaleWidth);
-                            break;
-                        case Shape.SquareOutline:
-                            g.DrawRectangle(pen, 0, 0, poiSettings.IconSize * scaleWidth - 1, poiSettings.IconSize * scaleWidth - 1);
-                            break;
-                        case Shape.Polygon:
-                            var halfSize = poiSettings.IconSize / 2;
-                            var cutSize = poiSettings.IconSize / 10;
-                            PointF[] curvePoints =
+                    case Shape.Square:
+                    case Shape.SquareOutline:
+                        var squarePoints = new PointF[]
+                        {
+                            new PointF(0, 0),
+                            new PointF(poiSettings.IconSize, 0),
+                            new PointF(poiSettings.IconSize, poiSettings.IconSize),
+                            new PointF(0, poiSettings.IconSize)
+                        }.Select(point => point.Rotate(_rotateDegrees).Multiply(scaleWidth, scaleHeight)).ToArray().MoveToOrigin(iconPadding);
+
+                        bitmap = squarePoints.ToBitmap(iconPadding);
+                        using (var g = Graphics.FromImage(bitmap))
+                        {
+                            g.SmoothingMode = SmoothingMode.HighQuality;
+                            if (poiSettings.IconShape == Shape.Square)
                             {
+                                g.FillPolygon(brush, squarePoints);
+                            }
+                            else
+                            {
+                                g.DrawPolygon(pen, squarePoints);
+                            }
+                        }
+                        break;
+                    case Shape.Ellipse:
+                    case Shape.EllipseOutline:
+                        bitmap = new SizeF(poiSettings.IconSize * scaleWidth + poiSettings.IconThickness, poiSettings.IconSize * scaleWidth + poiSettings.IconThickness).ToBitmap(iconPadding); // Don't distort - use scaleWidth for both
+                        using (var g = Graphics.FromImage(bitmap))
+                        {
+                            g.SmoothingMode = SmoothingMode.HighQuality;
+                            if (poiSettings.IconShape == Shape.Ellipse)
+                            {
+                                g.FillEllipse(brush, iconPadding, iconPadding, poiSettings.IconSize * scaleWidth, poiSettings.IconSize * scaleWidth);
+                            }
+                            else
+                            {
+                                g.DrawEllipse(pen, iconPadding, iconPadding, poiSettings.IconSize * scaleWidth, poiSettings.IconSize * scaleWidth);
+                            }
+                        }
+                        break;
+                    case Shape.Polygon:
+                        var halfSize = poiSettings.IconSize / 2f;
+                        var cutSize = poiSettings.IconSize / 10f;
+                        var polygonPoints = new PointF[]
+                        {
                                 new PointF(0, halfSize), new PointF(halfSize - cutSize, halfSize - cutSize),
                                 new PointF(halfSize, 0), new PointF(halfSize + cutSize, halfSize - cutSize),
                                 new PointF(poiSettings.IconSize, halfSize),
                                 new PointF(halfSize + cutSize, halfSize + cutSize),
                                 new PointF(halfSize, poiSettings.IconSize),
                                 new PointF(halfSize - cutSize, halfSize + cutSize)
-                            };
+                        }.Select(point => point.Multiply(scaleWidth)).ToArray().MoveToOrigin(iconPadding);
 
-                            for (var i = 0; i < curvePoints.Length; i++)
-                            {
-                                curvePoints[i] = new PointF(curvePoints[i].X * scaleWidth, curvePoints[i].Y * scaleWidth);
-                            }
+                        bitmap = polygonPoints.ToBitmap(iconPadding);
+                        using (var g = Graphics.FromImage(bitmap))
+                        {
+                            g.SmoothingMode = SmoothingMode.HighQuality;
+                            g.FillPolygon(brush, polygonPoints);
+                        }
+                        break;
+                    case Shape.Cross:
+                        var a = poiSettings.IconSize * 0.25f;
+                        var b = poiSettings.IconSize * 0.50f;
+                        var c = poiSettings.IconSize * 0.75f;
+                        var d = poiSettings.IconSize;
 
-                            g.FillPolygon(brush, curvePoints);
-                            break;
-                        case Shape.Cross:
-                            var a = poiSettings.IconSize * 0.25f;
-                            var b = poiSettings.IconSize * 0.50f;
-                            var c = poiSettings.IconSize * 0.75f;
-                            var d = poiSettings.IconSize;
-
-                            PointF[] crossLinePoints =
-                            {
+                        var crossPoints = new PointF[]
+                        {
                                 new PointF(0, a), new PointF(a, 0), new PointF(b, a), new PointF(c, 0),
                                 new PointF(d, a), new PointF(c, b), new PointF(d, c), new PointF(c, d),
                                 new PointF(b, c), new PointF(a, d), new PointF(0, c), new PointF(a, b),
                                 new PointF(0, a),
-                            };
+                        }.Select(point => point.Multiply(scaleWidth, scaleHeight)).ToArray().MoveToOrigin(iconPadding);
 
-                            for (var i = 0; i < crossLinePoints.Length; i++)
+                        bitmap = crossPoints.ToBitmap(iconPadding);
+                        using (var g = Graphics.FromImage(bitmap))
+                        {
+                            g.SmoothingMode = SmoothingMode.HighQuality;
+
+                            for (var p = 0; p < crossPoints.Length - 1; p++)
                             {
-                                crossLinePoints[i] = new PointF(crossLinePoints[i].X * scaleWidth, crossLinePoints[i].Y * scaleHeight);
+                                g.DrawLine(pen, crossPoints[p], crossPoints[p + 1]);
                             }
-
-                            for (var p = 0; p < crossLinePoints.Length - 1; p++)
-                            {
-                                g.DrawLine(pen, crossLinePoints[p], crossLinePoints[p + 1]);
-                            }
-
-                            break;
-                    }
+                        }
+                        break;
                 }
 
                 _iconCache[cacheKey] = bitmap;
@@ -416,10 +431,10 @@ namespace MapAssist.Helpers
             return _iconCache[cacheKey];
         }
 
-        private Point GetIconOffset(IconRendering poiSettings)
+        private PointF GetIconOffset(IconRendering poiSettings)
         {
             var bitmap = GetIcon(poiSettings);
-            return new Point(bitmap.Width / 2, bitmap.Height / 2);
+            return bitmap.Center();
         }
     }
 }

--- a/Helpers/Extensions.cs
+++ b/Helpers/Extensions.cs
@@ -17,7 +17,11 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  **/
 
+using System;
 using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using GameOverlay.Windows;
 using MapAssist.Types;
 
 namespace MapAssist.Helpers
@@ -26,9 +30,92 @@ namespace MapAssist.Helpers
     {
         public static bool IsWaypoint(this GameObject obj) => obj.ToString().Contains("Waypoint");
 
-        public static Point OffsetFrom(this Point point, Point offset)
+        public static PointF OffsetFrom(this PointF point, float x, float y)
         {
-            return new Point(point.X - offset.X, point.Y - offset.Y);
+            return new PointF(point.X - x, point.Y - y);
+        }
+
+        public static PointF OffsetFrom(this PointF point, PointF offset)
+        {
+            return point.OffsetFrom(offset.X, offset.Y);
+        }
+
+        public static PointF Multiply(this PointF point, float quantity)
+        {
+            return point.Multiply(quantity, quantity);
+        }
+
+        public static PointF Multiply(this PointF point, float x, float y)
+        {
+            return new PointF(point.X * x, point.Y * y);
+        }
+
+        public static PointF Rotate(this PointF point, float angleDegrees)
+        {
+            return point.Rotate(angleDegrees, new Point(0, 0));
+        }
+
+        public static PointF Rotate(this PointF point, float angleDegrees, PointF centerPoint)
+        {
+            var angleRadians = angleDegrees * Math.PI / 180d;
+
+            return new PointF(
+                (float)(centerPoint.X + Math.Cos(angleRadians) * (point.X - centerPoint.X) - Math.Sin(angleRadians) * (point.Y - centerPoint.Y)),
+                (float)(centerPoint.Y + Math.Sin(angleRadians) * (point.X - centerPoint.X) + Math.Cos(angleRadians) * (point.Y - centerPoint.Y))
+            );
+        }
+
+        public static Point ToPoint(this PointF point)
+        {
+            return new Point((int)Math.Round(point.X), (int)Math.Round(point.Y));
+        }
+
+        public static GameOverlay.Drawing.Point ToGameOverlayPoint(this PointF point)
+        {
+            return new GameOverlay.Drawing.Point((int)Math.Round(point.X), (int)Math.Round(point.Y));
+        }
+
+        public static PointF Center(this SizeF size)
+        {
+            return new PointF(size.Width / 2f, size.Height / 2f);
+        }
+
+        public static PointF Center(this Bitmap bitmap)
+        {
+            return new PointF(bitmap.Width / 2f, bitmap.Height / 2f);
+        }
+
+        public static PointF Center(this GraphicsWindow window)
+        {
+            return new PointF(window.Width / 2f, window.Height / 2f);
+        }
+
+        public static PointF[] MoveToOrigin(this PointF[] points, float padding = 0)
+        {
+            var minX = points.Min(point => point.X);
+            var minY = points.Min(point => point.Y);
+
+            return points.Select(point => new PointF(point.X - minX + padding, point.Y - minY + padding)).ToArray();
+        }
+
+        public static SizeF ToSizeF(this PointF[] points)
+        {
+            var minX = points.Min(point => point.X);
+            var maxX = points.Max(point => point.X);
+            var minY = points.Min(point => point.Y);
+            var maxY = points.Max(point => point.Y);
+
+            return new SizeF(maxX - minX, maxY - minY);
+        }
+
+        public static Bitmap ToBitmap(this PointF[] points, float padding = 0)
+        {
+            return points.ToSizeF().ToBitmap(padding);
+        }
+
+        public static Bitmap ToBitmap(this SizeF size, float padding = 0)
+        {
+            return new Bitmap((int)Math.Ceiling(size.Width + padding * 2), (int)Math.Ceiling(size.Height + padding * 2), PixelFormat.Format32bppArgb);
         }
     }
 }

--- a/Helpers/ImageUtils.cs
+++ b/Helpers/ImageUtils.cs
@@ -93,17 +93,7 @@ namespace MapAssist.Helpers
             return newBitmap;
         }
 
-        public static Point RotatePoint(Point inputPoint, Point centerPoint, float angleDegrees)
-        {
-            var angleRadians = angleDegrees * Math.PI / 180d;
-
-            return new Point(
-                (int)(centerPoint.X + Math.Cos(angleRadians) * (inputPoint.X - centerPoint.X) - Math.Sin(angleRadians) * (inputPoint.Y - centerPoint.Y)),
-                (int)(centerPoint.Y + Math.Sin(angleRadians) * (inputPoint.X - centerPoint.X) + Math.Cos(angleRadians) * (inputPoint.Y - centerPoint.Y))
-            );
-        }
-
-        public static (Bitmap, Point) CropBitmap(Bitmap originalBitmap)
+        public static (Bitmap, Point) CropBitmap(Bitmap originalBitmap, int padding = 0)
         {
             // Find the min/max non-white/transparent pixels
             var min = new Point(int.MaxValue, int.MaxValue);
@@ -122,7 +112,7 @@ namespace MapAssist.Helpers
                     {
                         var data = scan0 + y * bData.Stride + x * bitsPerPixel / 8;
                         // data[0 = blue, 1 = green, 2 = red, 3 = alpha]
-                        if (data[3] == byte.MaxValue)
+                        if (data[3] > 0)
                         {
                             if (x < min.X) min.X = x;
                             if (y < min.Y) min.Y = y;
@@ -138,12 +128,13 @@ namespace MapAssist.Helpers
 
             // Create a new bitmap from the crop rectangle
             var cropRectangle = new Rectangle(min.X, min.Y, max.X - min.X, max.Y - min.Y);
-            var newBitmap = new Bitmap(cropRectangle.Width, cropRectangle.Height);
+            var newBitmap = new Bitmap(cropRectangle.Width + padding * 2, cropRectangle.Height + padding * 2);
             using (var g = Graphics.FromImage(newBitmap))
             {
-                g.DrawImage(originalBitmap, 0, 0, cropRectangle, GraphicsUnit.Pixel);
+                g.DrawImage(originalBitmap, padding, padding, cropRectangle, GraphicsUnit.Pixel);
             }
 
+            min.Offset(-padding, -padding);
             return (newBitmap, min);
         }
 


### PR DESCRIPTION
- Some improved default configurations
- Changing everything to be PointF instead of Point to help things look crispier (still rounded to the pixel at the end, but all the math in the middle is more accurate)
- Render points of interest on every frame (no noticeable change in fps) instead of being blown up and pixelated when rendered on the background
- Line up the center overlay with the in game map
- Fix a few instances of bitmaps getting cropped (like the ellipse icon) 

Before:
![image](https://user-images.githubusercontent.com/1294559/145070297-d5dd8f32-9408-46fb-8854-2ecdcce213ca.png)

After: 
![image](https://user-images.githubusercontent.com/1294559/145070402-96ecb135-423c-46ab-b3c4-8cabdd25e758.png)
