### PR TITLE
Revert "Correction for Essence of Hatred typo  (#115)"

### DIFF
--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -1903,7 +1903,7 @@ namespace MapAssist.Types
             { 652, "Mephisto's Brain" },
             { 653, "Token of Absolution" },
             { 654, "Twisted Essence of Suffering" },
-            { 655, "Charged Essence of Hatred" },
+            { 655, "Charged Essense of Hatred" },
             { 656, "Burning Essence of Terror" },
             { 657, "Festering Essence of Destruction" },
             { 658, "Standard of Heroes" }


### PR DESCRIPTION
This reverts commit 77d57281fa731f77c87134e92a59c1e139dc9872.