### PR TITLE
Do not reset offsets when player unit is reset

### DIFF
--- a/Helpers/GameManager.cs
+++ b/Helpers/GameManager.cs
@@ -280,12 +280,6 @@ namespace MapAssist.Helpers
         public static void ResetPlayerUnit()
         {
             _PlayerUnit = default;
-            _UnitHashTableOffset = IntPtr.Zero;
-            _ExpansionCheckOffset = IntPtr.Zero;
-            _GameIPOffset = IntPtr.Zero;
-            _MenuPanelOpenOffset = IntPtr.Zero;
-            _MenuDataOffset = IntPtr.Zero;
-            _RosterDataOffset = IntPtr.Zero;
         }
         
         public static void Dispose()


### PR DESCRIPTION
This ends up causing us to scan for these offsets again which is rather heavy. The tradeoff here is that when supporting multiboxing we do not support them being on different versions of D2R. Which I believe to be an acceptable edge case.