### PR TITLE
Update ItemFilter.yaml

### DIFF
--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -20,9 +20,7 @@ Thresher:
 
 # This mage plate rule will look for any normal/superior mage plate with 3 or 4 sockets
 Mage Plate:
- - Qualities: 
-    - normal
-    - superior
+ - Qualities: [normal, superior]
    Sockets: [0, 3]
 
 # This monarch rule is really 2 separate rules.  Notice the "-" on each line
@@ -133,20 +131,13 @@ Matriarchal Javelin:
 
 ### Misc
 Amulet:
- - Qualities: 
-   - magic
-   - rare
-   - unique
-   - set
+ - Qualities: [magic, rare, unique, set]
 Jewel:
- - Qualities: 
-   - magic
-   - rare
-   - unique
+ - Qualities: [magic, rare, unique]
 Small Charm:
  - Qualities: [magic, unique]
 Large Charm:
- - Qualities: unique
+ - Qualities: [unique]
 Grand Charm:
  - Qualities: [magic, unique]
 Key of Terror:

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -9,14 +9,14 @@
 # The first line or "Key" is the item base name, in the next case, "Harlequin Crest" is a unique "Shako"
 # Alert to any unique Shako, regardless of any other modifiers (sockets, eth)
 Shako:
- - Qualities: unique
+ - Qualities: [unique] #Harlequin Crest
  
 # This thresher rule will look for only ethereal threshers with 4 sockets that are either normal/superior quality
 Thresher:
  - Ethereal: true
    Qualities: [normal, superior]
    Sockets: [0, 4]
- - Qualities: [unique] # The Reaper's Toll
+ - Qualities: [unique] #The Reaper's Toll
 
 # This mage plate rule will look for any normal/superior mage plate with 3 or 4 sockets
 Mage Plate:

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -28,7 +28,7 @@ Mage Plate:
 # This monarch rule is really 2 separate rules.  Notice the "-" on each line
 # This will show all magic monarchs, as well as monarchs with 4 sockets of any quality (since quality is not specific in this rule)
 Monarch:
- - Qualities: magic
+ - Qualities: [magic]
  - Sockets: [4]
 
 
@@ -45,12 +45,12 @@ x-bases:
   Sockets: [0, 3, 4]
   Ethereal: false
  - &merc-wep-base
-  Ethereal: true
+  Ethereal: false
   Qualities: [normal, superior]
   Sockets: [4]
  - &pally-shield-base
-   Qualities: [normal, superior]
-   Sockets: [0, 4]
+  Qualities: [normal, superior]
+  Sockets: [0, 4]
 # This ring rule will show all magic, rare, and unique rings
 Ring:
  - Qualities: [magic, rare, unique]
@@ -152,6 +152,11 @@ Grand Charm:
 Key of Terror:
 Key of Hate:
 Key of Destruction:
+#Charged Essence of Hatred:
+#Twisted Essence of Suffering:
+Burning Essence of Terror:
+Festering Essence of Destruction:
+Token of Absolution:
 
 ### Exceptional Boots
 Demonhide Boots:
@@ -232,7 +237,7 @@ Diadem:
  - Qualities: [magic, rare]
  - Qualities: unique #Griffon's Eye
 
-### Druid Pelts
+### Elite Druid Pelts
 Blood Spirit:
  - Qualities: [magic, rare]
 Sun Spirit:
@@ -244,19 +249,38 @@ Sky Spirit:
 Dream Spirit:
  - Qualities: [magic, rare]
 
- ### Barbarian Helms
-Carnage Helm:
- - Qualities: [magic, rare]
-Fury Visor:
- - Qualities: [magic, rare]
-Destroyer Helm:
- - Qualities: [magic, rare]
-Conquieror Crown:
- - Qualities: [magic, rare]
-Guardian Crown:
- - Qualities: [magic, rare]
+##Exceptional and Normal pelts
+Alpha Helm:
+ - Qualities: [rare]
+Griffon Headdress:
+ - Qualities: [rare]
+Hunter's Guise:
+ - Qualities: [rare]
+Sacred Feathers:
+ - Qualities: [rare]
+Totemic Mask:
+ - Qualities: [rare]
+ - Qualities: unique #Jalal's Mane
+Antlers:
+ - Qualities: [rare]
+Falcon Mask:
+ - Qualities: [rare]
+Hawk Helm:
+ - Qualities: [rare]
 
- ### Paladin Shields
+### Barbarian Helms
+#Carnage Helm:
+# - Qualities: [magic, rare]
+#Fury Visor:
+# - Qualities: [magic, rare]
+#Destroyer Helm:
+#- Qualities: [magic, rare]
+#Conquieror Crown:
+# - Qualities: [magic, rare]
+#Guardian Crown:
+# - Qualities: [magic, rare]
+
+### Paladin Shields
 Akaran Targe:
  - *pally-shield-base
 Akaran Rondache:
@@ -264,6 +288,13 @@ Akaran Rondache:
 Sacred Targe:
  - *pally-shield-base
 Sacred Rondache:
+ - *pally-shield-base
+Vortex Shield:
+ - *pally-shield-base
+Zakarum Shield:
+ - *pally-shield-base
+ - Qualities: unique #Upped Herald of Zakarum
+Crown Shield:
  - *pally-shield-base
 
 ### Runes
@@ -299,8 +330,8 @@ Perfect Topaz:
 Perfect Skull:
 
 ### Uniques
-#HoZ
-Zakarum Shield:
+#Herald of Zakarum
+Gilded Shield:
  - Qualities: unique
 #Ribcracker
 Quarterstaff:
@@ -311,21 +342,15 @@ Serpentskin Armor:
 #Skullder's Ire
 Russet Armor:
  - Qualities: unique
- #Aldur's Advance
+#Aldur's Advance
  - Qualities: set
-#Jalal's Mane
-Totemic Mask:
- - Qualities: unique
 #Oculus
 Swirling Crystal:
  - Qualities: unique
- #Tal Rasha's Lidless Eye
+#Tal Rasha's Lidless Eye
  - Qualities: set
 #Homunculus
 Hierophant Trophy:
- - Qualities: unique
-#Herald of Zakarum
-Gilded Shield:
  - Qualities: unique
 #Vampire Gaze
 Grim Helm:
@@ -377,6 +402,9 @@ Heavy Belt:
  - Qualities: unique
 #Nosferatu's Coil
 Vampirefang Belt:
+ - Qualities: unique
+#Thundergod's Vigor
+War Belt:
  - Qualities: unique
 #Ondal's Wisdom
 Elder Staff:

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -415,6 +415,9 @@ Bone Knife:
 #Fleshripper
 Fanged Knife:
  - Qualities: [unique]
+#Windforce
+Hydra Bow:
+ - Qualities: unique
 
 ### Sets
 #Tal Rasha's Horadric Crest

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -16,7 +16,7 @@ Thresher:
  - Ethereal: true
    Qualities: [normal, superior]
    Sockets: [0, 4]
- - Qualities: unique # The Reaper's Toll
+ - Qualities: [unique] # The Reaper's Toll
 
 # This mage plate rule will look for any normal/superior mage plate with 3 or 4 sockets
 Mage Plate:
@@ -96,13 +96,13 @@ Hellforge Plate:
  - *merc-arm-base
 Lacquered Plate:
  - *merc-arm-base
- - Qualities: Set #Tal Rasha's Guardianship
+ - Qualities: [set] #Tal Rasha's Guardianship
 Shadow Plate:
  - *merc-arm-base
 Sacred Armor:
  - *merc-arm-base
- - Qualities: unique #Tyrael's Might
- - Qualities: set #Immortal King's Soul Cage
+ - Qualities: [unique] #Tyrael's Might
+ - Qualities: [set] #Immortal King's Soul Cage
 
 ### Bases
 Archon Plate:
@@ -127,7 +127,7 @@ Feral Claws:
    Sockets: [3]
 Matriarchal Javelin:
  - Qualities: [magic, rare]
- - Qualities: unique #Thunderstroke
+ - Qualities: [unique] #Thunderstroke
 
 ### Misc
 Amulet:
@@ -151,59 +151,59 @@ Token of Absolution:
 
 ### Exceptional Boots
 Demonhide Boots:
- - Qualities: rare
+ - Qualities: [rare]
 Sharkskin Boots:
- - Qualities: rare
+ - Qualities: [rare]
 Mesh Boots:
- - Qualities: rare
+ - Qualities: [rare]
 Battle Boots:
- - Qualities: rare
+ - Qualities: [rare]
  #War Traveler
- - Qualities: unique
+ - Qualities: [unique]
 War Boots:
- - Qualities: rare
+ - Qualities: [rare]
 
 ### Elite Boots
 Wyrmhide Boots:
- - Qualities: rare
+ - Qualities: [rare]
 Scarabshell Boots:
- - Qualities: rare
+ - Qualities: [rare]
 #Sandstorm Trek
- - Qualities: unique
+ - Qualities: [unique]
 Boneweave Boots:
- - Qualities: rare
+ - Qualities: [rare]
 Mirrored Boots:
- - Qualities: rare
+ - Qualities: [rare]
 Myrmidon Greaves:
- - Qualities: rare
+ - Qualities: [rare]
  
 ### Exceptional Gloves
 Demonhide Gloves:
- - Qualities: rare
+ - Qualities: [rare]
 Sharkskin Gloves:
- - Qualities: rare
+ - Qualities: [rare]
 Heavy Bracers:
- - Qualities: rare
+ - Qualities: [rare]
 #Trang-Oul's Claws
- - Qualities: set
+ - Qualities: [set]
 Battle Gauntlets:
- - Qualities: rare
+ - Qualities: [rare]
 War Gauntlets:
- - Qualities: rare
+ - Qualities: [rare]
  
 ### Elite Gloves
 Bramble Mitts:
- - Qualities: rare
+ - Qualities: [rare]
 Vampirebone Gloves:
- - Qualities: rare
+ - Qualities: [rare]
  #Dracul's Grasp
- - Qualities: unique
+ - Qualities: [unique]
 Vambraces:
- - Qualities: rare
+ - Qualities: [rare]
 Crusader Gauntlets:
- - Qualities: rare
+ - Qualities: [rare]
 Ogre Gauntlets:
- - Qualities: rare
+ - Qualities: [rare]
  
 ### Helmets
 Bone Visage:
@@ -212,21 +212,21 @@ Bone Visage:
 Demonhead:
  - Qualities: [normal, superior]
    Sockets: [0, 3]
- - Qualities: unique #Andariel's Visage
+ - Qualities: [unique] #Andariel's Visage
 Winged Helm:
- - Qualities: set #Guillaume's Face
+ - Qualities: [set] #Guillaume's Face
 
 ### Circlets
 Circlet:
  - Qualities: [magic, rare]
 Tiara:
  - Qualities: [magic, rare]
- - Qualities: unique #Kira's Guardian
+ - Qualities: [unique] #Kira's Guardian
 Coronet:
  - Qualities: [magic, rare]
 Diadem:
  - Qualities: [magic, rare]
- - Qualities: unique #Griffon's Eye
+ - Qualities: [unique] #Griffon's Eye
 
 ### Elite Druid Pelts
 Blood Spirit:
@@ -251,7 +251,7 @@ Sacred Feathers:
  - Qualities: [rare]
 Totemic Mask:
  - Qualities: [rare]
- - Qualities: unique #Jalal's Mane
+ - Qualities: [unique] #Jalal's Mane
 Antlers:
  - Qualities: [rare]
 Falcon Mask:
@@ -284,7 +284,7 @@ Vortex Shield:
  - *pally-shield-base
 Zakarum Shield:
  - *pally-shield-base
- - Qualities: unique #Upped Herald of Zakarum
+ - Qualities: [unique] #Upped Herald of Zakarum
 Crown Shield:
  - *pally-shield-base
 
@@ -323,103 +323,103 @@ Perfect Skull:
 ### Uniques
 #Herald of Zakarum
 Gilded Shield:
- - Qualities: unique
+ - Qualities: [unique]
 #Ribcracker
 Quarterstaff:
- - Qualities: unique
+ - Qualities: [unique]
 #Skin of the Vipermagi
 Serpentskin Armor:
- - Qualities: unique
+ - Qualities: [unique]
 #Skullder's Ire
 Russet Armor:
- - Qualities: unique
+ - Qualities: [unique]
 #Aldur's Advance
- - Qualities: set
+ - Qualities: [set]
 #Oculus
 Swirling Crystal:
- - Qualities: unique
+ - Qualities: [unique]
 #Tal Rasha's Lidless Eye
- - Qualities: set
+ - Qualities: [set]
 #Homunculus
 Hierophant Trophy:
- - Qualities: unique
+ - Qualities: [unique]
 #Vampire Gaze
 Grim Helm:
- - Qualities: unique
+ - Qualities: [unique]
 #Titan's Revenge
 Ceremonial Javelin:
- - Qualities: unique
+ - Qualities: [unique]
 #Shaftstop
 Mesh Armor:
- - Qualities: unique
+ - Qualities: [unique]
 #Arachnid Mesh
 Spiderweb Sash:
- - Qualities: unique
+ - Qualities: [unique]
 #Eschuta's Temper
 Eldritch Orb:
- - Qualities: unique
+ - Qualities: [unique]
 #Arreat's Face
 Slayer Guard:
- - Qualities: unique
+ - Qualities: [unique]
 #Death's Web
 Unearthed Wand:
- - Qualities: unique
+ - Qualities: [unique]
 #Chance Guards
 Chain Gloves:
- - Qualities: unique
+ - Qualities: [unique]
 #Death's Fathom
 Dimensional Shard:
- - Qualities: unique
+ - Qualities: [unique]
 #Nightwing's Veil
 Spired Helm:
- - Qualities: unique
+ - Qualities: [unique]
 #Crown of Ages
 Corona:
- - Qualities: unique
+ - Qualities: [unique]
 #Verdungo's Hearty Cord
 Mithril Coil:
- - Qualities: unique
+ - Qualities: [unique]
 #String of Ears
 Demonhide Sash:
- - Qualities: unique
+ - Qualities: [unique]
 #Duriel's Shell
 Cuirass:
- - Qualities: unique
+ - Qualities: [unique]
 #Razortail
 Sharkskin Belt:
- - Qualities: unique
+ - Qualities: [unique]
 #Goldwrap
 Heavy Belt:
- - Qualities: unique
+ - Qualities: [unique]
 #Nosferatu's Coil
 Vampirefang Belt:
- - Qualities: unique
+ - Qualities: [unique]
 #Thundergod's Vigor
 War Belt:
- - Qualities: unique
+ - Qualities: [unique]
 #Ondal's Wisdom
 Elder Staff:
- - Qualities: unique
+ - Qualities: [unique]
 #Goblin Toe
 Light Plated Boots:
- - Qualities: unique
+ - Qualities: [unique]
 #Magefist
 Light Gauntlets:
- - Qualities: unique
+ - Qualities: [unique]
 #Gull
 Dagger:
- - Qualities: unique
+ - Qualities: [unique]
 #Wizardspike
 Bone Knife:
- - Qualities: unique
+ - Qualities: [unique]
 #Fleshripper
 Fanged Knife:
- - Qualities: unique
+ - Qualities: [unique]
 
 ### Sets
 #Tal Rasha's Horadric Crest
 Death Mask:
- - Qualities: set
+ - Qualities: [set]
 #Tal Rasha's Fine Spun Cloth
 Mesh Belt:
- - Qualities: set
+ - Qualities: [set]


### PR DESCRIPTION
- &merc-wep-base to include non-ethereal by default. 
- Added Essences and Token of Absolution (Burning Essence of Hatred and Festering Essence of Suffering turned OFF by default)
- Added Exceptional and Normal Druid Pelts due to being able to roll +5 Hurricane on all bases
- Disabled Barbarian Helms by default
- Added all Elite Paladin Shields due to popular demand
- Moved Upgraded (Upped) Herald of Zakarum (Zakarum Shield) and Jalal's Mane
- Added Thundergod's Vigor
- Added Windforce to default
- Cleaned up formatting discrepancies