### PR TITLE
Arachnid lair label fix

### DIFF
--- a/Types/Area.cs
+++ b/Types/Area.cs
@@ -508,7 +508,7 @@ namespace MapAssist.Types
                 Level = new int[] { 24, 54, 82 }
             },
             [Area.SpiderCave] = new AreaLabel() {
-                Text = "Spider Cave",
+                Text = "Arachnid Lair",
                 Level = new int[] { 21, 50, 79 }
             },
             [Area.SpiderCavern] = new AreaLabel() {


### PR DESCRIPTION
Someone in support pointed out the Arachnid Lair cave in Act 3 was mislabeled.