### PR TITLE
Fix for Area-specific POIs and Act 5 Super Chest

### DIFF
--- a/Helpers/PointOfInterestHandler.cs
+++ b/Helpers/PointOfInterestHandler.cs
@@ -124,7 +124,8 @@ namespace MapAssist.Helpers
             GameObject.ArcaneLargeChestLeft,
             GameObject.ArcaneLargeChestRight,
             GameObject.ArcaneSmallChestLeft,
-            GameObject.ArcaneSmallChestRight
+            GameObject.ArcaneSmallChestRight,
+            GameObject.ExpansionSpecialChest,
         };
 
         private static readonly HashSet<GameObject> NormalChests = new HashSet<GameObject>
@@ -174,7 +175,6 @@ namespace MapAssist.Helpers
             GameObject.ExpansionSmallChestLeft,
             GameObject.ExpansionSmallChestRight,
             GameObject.ExpansionExplodingChest,
-            GameObject.ExpansionSpecialChest,
             GameObject.ExpansionSnowyWoodChestLeft,
             GameObject.ExpansionSnowyWoodChestRight,
             GameObject.ExpansionSnowyWoodChest2Left,
@@ -373,6 +373,36 @@ namespace MapAssist.Helpers
                     continue;
                 }
 
+                // Area-specific quest objects
+                if (AreaSpecificQuestObjects.ContainsKey(areaData.Area))
+                {
+                    if (AreaSpecificQuestObjects[areaData.Area].ContainsKey(obj))
+                    {
+                        pointOfInterest.Add(new PointOfInterest
+                        {
+                            Label = AreaSpecificQuestObjects[areaData.Area][obj],
+                            Position = points[0],
+                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.Quest,
+                            Type = PoiType.AreaSpecificQuest
+                        });
+                    }
+                }
+
+                // Area-specific landmarks
+                if (AreaPortals.ContainsKey(areaData.Area))
+                {
+                    if (AreaPortals[areaData.Area].ContainsKey(obj))
+                    {
+                        pointOfInterest.Add(new PointOfInterest
+                        {
+                            Label = Utils.GetPortalName(AreaPortals[areaData.Area][obj], gameData.Difficulty),
+                            Position = points[0],
+                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.Portal,
+                            Type = PoiType.AreaPortal
+                        });
+                    }
+                }
+
                 // Waypoints
                 if (obj.IsWaypoint())
                 {
@@ -397,34 +427,6 @@ namespace MapAssist.Helpers
                             Label = questObjectName,
                             Position = point,
                             RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.Quest
-                        });
-                    }
-                }
-                // Area-specific quest objects
-                else if (AreaSpecificQuestObjects.ContainsKey(areaData.Area))
-                {
-                    if (AreaSpecificQuestObjects[areaData.Area].ContainsKey(obj))
-                    {
-                        pointOfInterest.Add(new PointOfInterest
-                        {
-                            Label = AreaSpecificQuestObjects[areaData.Area][obj],
-                            Position = points[0],
-                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.Quest,
-                            Type = PoiType.AreaSpecificQuest
-                        });
-                    }
-                }
-                // Area-specific landmarks
-                else if (AreaPortals.ContainsKey(areaData.Area))
-                {
-                    if (AreaPortals[areaData.Area].ContainsKey(obj))
-                    {
-                        pointOfInterest.Add(new PointOfInterest
-                        {
-                            Label = Utils.GetPortalName(AreaPortals[areaData.Area][obj], gameData.Difficulty),
-                            Position = points[0],
-                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.Portal,
-                            Type = PoiType.AreaPortal
                         });
                     }
                 }


### PR DESCRIPTION
Fixed mislabeled Super Chest in Act 5: `ExpansionSpecialChest`

Also while testing I noticed a bug with `AreaSpecificQuestObjects` and `AreaPortals` preventing other objects (anything in those areas checked lower in the `else if` conditions) would not show in the handful of areas in those two dictionaries.  For example, this prevented shrine or chests from showing in Frigid Highlands, Arreat Plateau, and Frozen Tundra.

I separated the Area-specific logic to not be combined with the other `if/else if` checks, and now we can see a Super Chest that always spawns in Frigid Highlands.  Glacial Trail, Halls of Anguish, and Halls of Pain also have a Super Chest showing on the map now.

![frigid](https://user-images.githubusercontent.com/10291543/146119925-d72112cb-a1a0-4559-bdee-f8c858c12761.png)

