### PR TITLE
D2 path that contains spaces fix

### DIFF
--- a/Helpers/MapApi.cs
+++ b/Helpers/MapApi.cs
@@ -171,7 +171,7 @@ namespace MapAssist.Helpers
         private static string FindD2()
         {
             var providedPath = MapAssistConfiguration.Loaded.D2Path;
-            if (providedPath.Length > 0) providedPath = providedPath.TrimEnd('\\') + "\\";
+            if (providedPath.Length > 0) providedPath = providedPath.TrimEnd('\\');
             if (!string.IsNullOrEmpty(providedPath))
             {
                 if (Path.HasExtension(providedPath))


### PR DESCRIPTION
For some reason we are trimming \ then readding it? I've noticed this across multiple methods and I don't understand the reason for it? There seems to be a conflict between the **providedPath.TrimEnd('\\') + "\\";** and **_pipeClient.StartInfo.Arguments = "\"" + path + "\"";** If you change the **= "\"" + path + "\"";** to **= path** then the program works as long as the path doesn't contain any spaces.

I've tested the fix with following paths in yaml:
C:\MapAssist\D2
C:\Map Assist\D2
C:\Map Assist\D2\