### PR TITLE
Game Info configurability

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -5,7 +5,6 @@ HotkeyConfiguration:
   ToggleKey: '\'
   ZoomInKey: '+'
   ZoomOutKey: '-'
-  GameInfoKey: '['
 
 ## PrefetchAreas - Areas to preload so that they're hot and ready as soon as you go to them
 PrefetchAreas:
@@ -163,14 +162,16 @@ MapColorConfiguration:
   Walkable:
   Border: '255, 255, 255'
 
-## GameInfo - Displaying game server IP address
+## GameInfo - Display setting for game info
 GameInfo:
-  Enabled: true
+  ## ShowGameIP - Display game server IP address
+  ShowGameIP: true
+  ## HuntingIP - Set an IP address to display in green instead of red
+  HuntingIP: 'x.x.x.x'
+  ## ShowAreaLevel - Display current area and alvl
+  ShowAreaLevel: true
   ## ShowOverlayFPS - Developer setting, probably not useful
   ShowOverlayFPS: false
-
-## HuntingIP - Set an IP address to display in green instead of red
-HuntingIP: 'x.x.x.x'
 
 ## Path to D2LOD installation. Optional.
 ## Should only need to provide if we are not able to look it up

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -551,29 +551,33 @@ namespace MapAssist.Helpers
             var fontHeight = (fontSize + fontSize / 2f);
 
             // Game IP
-            if (MapAssistConfiguration.Loaded.GameInfo.Enabled)
+            if (MapAssistConfiguration.Loaded.GameInfo.ShowGameIP)
             {
-                var fontColor = _gameData.Session.GameIP == MapAssistConfiguration.Loaded.HuntingIP ? Color.Green : Color.Red;
+                var fontColor = _gameData.Session.GameIP == MapAssistConfiguration.Loaded.GameInfo.HuntingIP ? Color.Green : Color.Red;
 
                 var ipText = "Game IP: " + _gameData.Session.GameIP;
                 DrawText(gfx, anchor, ipText, "Consolas", 14, fontColor);
 
                 anchor.Y += fontHeight + 5;
+            }
 
+            // Area Level
+            if (MapAssistConfiguration.Loaded.GameInfo.ShowAreaLevel)
+            {
                 // Area Label
                 var areaText = "Area: " + Utils.GetAreaLabel(_areaData.Area, _gameData.Difficulty, true);
                 DrawText(gfx, anchor, areaText, "Consolas", 14, Color.FromArgb(255, 218, 100));
 
                 anchor.Y += fontHeight + 5;
+            }
 
-                // Overlay FPS
-                if (MapAssistConfiguration.Loaded.GameInfo.ShowOverlayFPS)
-                {
-                    var fpsText = "FPS: " + gfx.FPS.ToString() + "   " + "DeltaTime: " + e.DeltaTime.ToString();
-                    DrawText(gfx, anchor, fpsText, "Consolas", 14, Color.FromArgb(0, 255, 0));
+            // Overlay FPS
+            if (MapAssistConfiguration.Loaded.GameInfo.ShowOverlayFPS)
+            {
+                var fpsText = "FPS: " + gfx.FPS.ToString() + "   " + "DeltaTime: " + e.DeltaTime.ToString();
+                DrawText(gfx, anchor, fpsText, "Consolas", 14, Color.FromArgb(0, 255, 0));
 
-                    anchor.Y += fontHeight + 5;
-                }
+                anchor.Y += fontHeight + 5;
             }
 
             if (errorLoadingAreaData)

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -156,11 +156,6 @@ namespace MapAssist
                           (int)(MapAssistConfiguration.Loaded.RenderingConfiguration.InitialSize * 0.05f);
                     }
                 }
-
-                if (args.KeyChar == MapAssistConfiguration.Loaded.HotkeyConfiguration.GameInfoKey)
-                {
-                    MapAssistConfiguration.Loaded.GameInfo.Enabled = !MapAssistConfiguration.Loaded.GameInfo.Enabled;
-                }
             }
         }
 

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -44,9 +44,6 @@ namespace MapAssist.Settings
         [YamlMember(Alias = "D2Path", ApplyNamingConventions = false)]
         public string D2Path { get; set; }
 
-        [YamlMember(Alias = "HuntingIP", ApplyNamingConventions = false)]
-        public string HuntingIP { get; set; }
-
         [YamlMember(Alias = "PrefetchAreas", ApplyNamingConventions = false)]
         public Area[] PrefetchAreas { get; set; }
 
@@ -181,15 +178,18 @@ public class HotkeyConfiguration
 
     [YamlMember(Alias = "ZoomOutKey", ApplyNamingConventions = false)]
     public char ZoomOutKey { get; set; }
-
-    [YamlMember(Alias = "GameInfoKey", ApplyNamingConventions = false)]
-    public char GameInfoKey { get; set; }
 }
 
 public class GameInfoConfiguration
 {
-    [YamlMember(Alias = "Enabled", ApplyNamingConventions = false)]
-    public bool Enabled { get; set; }
+    [YamlMember(Alias = "ShowGameIP", ApplyNamingConventions = false)]
+    public bool ShowGameIP { get; set; }
+
+    [YamlMember(Alias = "HuntingIP", ApplyNamingConventions = false)]
+    public string HuntingIP { get; set; }
+
+    [YamlMember(Alias = "ShowAreaLevel", ApplyNamingConventions = false)]
+    public bool ShowAreaLevel { get; set; }
 
     [YamlMember(Alias = "ShowOverlayFPS", ApplyNamingConventions = false)]
     public bool ShowOverlayFPS { get; set; }


### PR DESCRIPTION
- individual `GameInfo` config settings can be toggled on/off
- removed the `GameInfoKey` so the GameInfo config toggles are static for the session
- `HuntingIP` was moved into `GameInfo`

This allows you to have GameInfo display the Area Level but not the Game Server IP address, or vise-versa (or show both, or hide both)

![game-info-toggles](https://user-images.githubusercontent.com/10291543/146289309-147df43d-3d85-4cce-9291-1e44c5d201e7.png)

