### PR TITLE
Update Mage Plate comment and sockets value to match

### DIFF
--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -18,7 +18,7 @@ Thresher:
    Sockets: [0, 4]
  - Qualities: unique # The Reaper's Toll
 
-# This mage plate rule will look for any normal/superior mage plate with 3 or 4 sockets
+# This mage plate rule will look for any normal/superior mage plate with 0 or 3 sockets
 Mage Plate:
  - Qualities: 
     - normal


### PR DESCRIPTION
The original Mage Plate definition was looking for 3 and 4 sockets, when it was updated, the comment was not updated to match