### PR TITLE
Remove set from monarch qualities because no set monarch exists

### DIFF
--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -26,9 +26,9 @@ Mage Plate:
     Sockets: [0, 3]
 
 # This monarch rule is 2 separate rules. Notice the "-" on each line
-# This will show unique and set monarchs as well as non-magical monarchs with 0 or 4 sockets
+# This will show unique monarchs as well as non-magical monarchs with 0 or 4 sockets
 Monarch:
-  - Qualities: [unique, set] # Stormshield and Milabrega's Orb
+  - Qualities: unique # Stormshield
   - Qualities: [normal, superior]
     Sockets: [0, 4]
 


### PR DESCRIPTION
I made a mistake when I added set to the Monarch qualities. As it turns out, Milabrega's Orb is a Kite Shield, and after verifying on the classic battle.net, I can confirm there is no set Monarch, so I am removing set from the qualities for Monarchs.