### PR TITLE
Fixes to Hidden Areas in Config GUI

### DIFF
--- a/AddAreaForm.Designer.cs
+++ b/AddAreaForm.Designer.cs
@@ -41,6 +41,7 @@ namespace MapAssist
             this.lstAreas.Name = "lstAreas";
             this.lstAreas.Size = new System.Drawing.Size(287, 173);
             this.lstAreas.TabIndex = 0;
+            this.lstAreas.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lstAreas_MouseDoubleClick);
             // 
             // btnAddArea
             // 

--- a/AddAreaForm.cs
+++ b/AddAreaForm.cs
@@ -22,21 +22,26 @@ namespace MapAssist
 
         private void AddAreaForm_Load(object sender, EventArgs e)
         {
-            lstAreas.Items.Clear();
-            foreach(var area in Enum.GetValues(typeof(Area)).Cast<Area>()){
-                if (area != Area.None)
+            var areas = new Dictionary<Area, string>();
+
+            foreach (var area in Enum.GetValues(typeof(Area)).Cast<Area>()){
+                if (area != Area.None && AreaExtensions.IsValid(area) && !MapAssistConfiguration.Loaded.HiddenAreas.Contains(area))
                 {
-                    lstAreas.Items.Add(AreaExtensions.Name(area));
+                    areas.Add(area, AreaExtensions.Name(area));
                 }
             }
+
+            lstAreas.DataSource = new BindingSource(areas, null);
+            lstAreas.ValueMember = "Key";
+            lstAreas.DisplayMember = "Value";
         }
 
-        private void btnAddArea_Click(object sender, EventArgs e)
+        private void AddSelectedArea(Area areaToAdd)
         {
+            var areaName = areaToAdd.NameInternal();
+
             var formParent = (ConfigEditor)Owner;
             var list = formParent.Controls.Find(listToAddTo, true).FirstOrDefault() as ListBox;
-            var areaToAdd = (Area)lstAreas.SelectedIndex;
-            var areaName = areaToAdd.NameInternal();
             if (!list.Items.Contains(areaName))
             {
                 list.Items.Add(areaName);
@@ -48,6 +53,18 @@ namespace MapAssist
                 }
                 Close();
             }
+        }
+
+        private void btnAddArea_Click(object sender, EventArgs e)
+        {
+            var areaToAdd = (Area)lstAreas.SelectedValue;
+            AddSelectedArea(areaToAdd);
+        }
+
+        private void lstAreas_MouseDoubleClick(object sender, EventArgs e)
+        {
+            var areaToAdd = (Area)lstAreas.SelectedValue;
+            AddSelectedArea(areaToAdd);
         }
     }
 }

--- a/Config.yaml
+++ b/Config.yaml
@@ -7,11 +7,11 @@ HotkeyConfiguration:
 HiddenAreas:
 - Rogue Encampment
 - Lut Gholein
-- Kurast Docks
+- Kurast Docktown
 - Pandemonium Fortress
 - Harrogath
 - Forgotten Tower
-- Nihlathak's Temple
+- Nihlathaks Temple
 RenderingConfiguration:
   Opacity: 0.5
   IconOpacity: 0.9

--- a/ConfigEditor.cs
+++ b/ConfigEditor.cs
@@ -126,7 +126,7 @@ namespace MapAssist
 
             foreach (var area in MapAssistConfiguration.Loaded.HiddenAreas)
             {
-                lstHidden.Items.Add(AreaExtensions.NameInternal(area));
+                lstHidden.Items.Add(AreaExtensions.Name(area));
             }
         }
 

--- a/Types/Area.cs
+++ b/Types/Area.cs
@@ -669,7 +669,7 @@ namespace MapAssist.Types
                 Level = new int[] { 33, 63, 83 }
             },
             [Area.HallsOfPain] = new AreaLabel() {
-                Text = "Halls of Pain",
+                Text = "Halls of Death's Calling",
                 Level = new int[] { 34, 64, 84 }
             },
             [Area.HallsOfVaught] = new AreaLabel() {


### PR DESCRIPTION
* Corrected label showing as `HallsOfPain` (items-localization.json uses `Halls of Death's Calling` as the lookup Key.

* Updated Config.yaml default hidden areas to use `Kurast Docktown` and `Nihlathaks Temple` (Localization lookup Keys)
* Changed Hidden Areas listbox to use `AreaExtensions.Name(area)` instead of `AreaExtensions.NameInternal(area)`
![Areas-config1](https://user-images.githubusercontent.com/10291543/147898160-7195687e-d844-4ead-b22e-663de91026ac.png)

* Double-clicking the Areas listbox adds the selected item (same as clicking the Add Area button)
* The Areas listbox will only show Areas that are not already added to Hidden Areas
![Areas-config2](https://user-images.githubusercontent.com/10291543/147898239-befd11cb-021c-4eda-89b1-6341e2aed6bb.png)

