### PR TITLE
Icon rendering order and new icon categories

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -50,14 +50,6 @@ MapConfiguration:
     IconShape: Cross
     IconSize: 6
     IconThickness: 2
-  Npc:
-    IconOutlineColor: '196, 196, 196'
-    IconShape: Cross
-    IconSize: 6
-    IconThickness: 2
-    LabelColor: '199, 179, 119'
-    LabelFontSize: 16
-    LabelFont: Exocet Blizzard Mixed Caps
   NextArea:
     IconColor: SpringGreen
     IconShape: Square

--- a/Config.yaml
+++ b/Config.yaml
@@ -36,12 +36,12 @@ MapConfiguration:
     IconSize: 6
     IconThickness: 2
   ChampionMonster:
-    IconOutlineColor: '33, 154, 253'
+    IconOutlineColor: 33, 154, 253
     IconShape: Cross
     IconSize: 6
     IconThickness: 2
   MinionMonster:
-    IconOutlineColor: '196, 196, 196'
+    IconOutlineColor: 196, 196, 196
     IconShape: Cross
     IconSize: 6
     IconThickness: 2
@@ -79,7 +79,7 @@ MapConfiguration:
     LabelFontSize: 16
     LabelFont: Exocet Blizzard Mixed Caps
   Player:
-    IconOutlineColor: '33, 136, 253'
+    IconOutlineColor: 33, 136, 253
     IconShape: Cross
     IconSize: 6
     IconThickness: 2

--- a/Config.yaml
+++ b/Config.yaml
@@ -36,20 +36,20 @@ MapConfiguration:
     IconSize: 6
     IconThickness: 2
   ChampionMonster:
-    IconOutlineColor: 33, 154, 253
+    IconOutlineColor: DarkRed
     IconShape: Cross
     IconSize: 6
     IconThickness: 2
   MinionMonster:
-    IconOutlineColor: 196, 196, 196
+    IconOutlineColor: 255, 150, 150
     IconShape: Cross
     IconSize: 6
-    IconThickness: 2
+    IconThickness: 1
   NormalMonster:
     IconOutlineColor: Gray
     IconShape: Cross
     IconSize: 6
-    IconThickness: 2
+    IconThickness: 1
   NextArea:
     IconColor: SpringGreen
     IconShape: Square

--- a/Config.yaml
+++ b/Config.yaml
@@ -35,8 +35,13 @@ MapConfiguration:
     IconShape: Cross
     IconSize: 6
     IconThickness: 2
-  EliteMonster:
-    IconOutlineColor: DarkRed
+  ChampionMonster:
+    IconOutlineColor: '33, 154, 253'
+    IconShape: Cross
+    IconSize: 6
+    IconThickness: 2
+  MinionMonster:
+    IconOutlineColor: '196, 196, 196'
     IconShape: Cross
     IconSize: 6
     IconThickness: 2
@@ -45,6 +50,14 @@ MapConfiguration:
     IconShape: Cross
     IconSize: 6
     IconThickness: 2
+  Npc:
+    IconOutlineColor: '196, 196, 196'
+    IconShape: Cross
+    IconSize: 6
+    IconThickness: 2
+    LabelColor: '199, 179, 119'
+    LabelFontSize: 16
+    LabelFont: Exocet Blizzard Mixed Caps
   NextArea:
     IconColor: SpringGreen
     IconShape: Square
@@ -74,6 +87,14 @@ MapConfiguration:
     LabelFontSize: 16
     LabelFont: Exocet Blizzard Mixed Caps
   Player:
+    IconOutlineColor: '33, 136, 253'
+    IconShape: Cross
+    IconSize: 6
+    IconThickness: 2
+    LabelColor: Chartreuse
+    LabelFontSize: 16
+    LabelFont: Exocet Blizzard Mixed Caps
+  PartyPlayer:
     IconOutlineColor: Chartreuse
     IconShape: Cross
     IconSize: 6

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -188,9 +188,6 @@ namespace MapAssist.Helpers
 
         private void DrawPointsOfInterest(Graphics gfx)
         {
-            var drawPoiIcons = new HashSet<(IconRendering, Point)>();
-            var drawPoiLabels = new HashSet<(PointOfInterestRendering, Point, string, Color?)>();
-
             foreach (var poi in _pointsOfInterest)
             {
                 if (poi.PoiMatchesPortal(_gameData.Objects, _gameData.Difficulty))
@@ -200,7 +197,7 @@ namespace MapAssist.Helpers
 
                 if (poi.RenderingSettings.CanDrawIcon())
                 {
-                    drawPoiIcons.Add((poi.RenderingSettings, poi.Position));
+                    DrawIcon(gfx, poi.RenderingSettings, poi.Position);
                 }
             }
 
@@ -228,11 +225,11 @@ namespace MapAssist.Helpers
                     if (poi.RenderingSettings.CanDrawLine() && poi.RenderingSettings.CanDrawLabel())
                     {
                         var poiPosition = MovePointInBounds(poi.Position, _gameData.PlayerPosition);
-                        drawPoiLabels.Add((poi.RenderingSettings, poiPosition, poi.Label, null));
+                        DrawText(gfx, poi.RenderingSettings, poiPosition, poi.Label);
                     }
                     else if (poi.RenderingSettings.CanDrawLabel())
                     {
-                        drawPoiLabels.Add((poi.RenderingSettings, poi.Position, poi.Label, null));
+                        DrawText(gfx, poi.RenderingSettings, poi.Position, poi.Label);
                     }
                 }
             }
@@ -247,25 +244,25 @@ namespace MapAssist.Helpers
                 {
                     if (MapAssistConfiguration.Loaded.MapConfiguration.Shrine.CanDrawIcon())
                     {
-                        drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.Shrine, gameObject.Position));
+                        DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Shrine, gameObject.Position);
                     }
 
                     if (MapAssistConfiguration.Loaded.MapConfiguration.Shrine.CanDrawLabel())
                     {
                         var label = Shrine.ShrineDisplayName(gameObject);
-                        drawPoiLabels.Add((MapAssistConfiguration.Loaded.MapConfiguration.Shrine, gameObject.Position, label, null));
+                        DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Shrine, gameObject.Position, label);
                     }
 
                     continue;
                 }
-                
+
                 if (gameObject.IsPortal())
                 {
                     var destinationArea = (Area)Enum.ToObject(typeof(Area), gameObject.ObjectData.InteractType);
 
                     if (MapAssistConfiguration.Loaded.MapConfiguration.Portal.CanDrawIcon())
                     {
-                        drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.Portal, gameObject.Position));
+                        DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Portal, gameObject.Position);
                     }
 
                     if (MapAssistConfiguration.Loaded.MapConfiguration.Portal.CanDrawLabel(destinationArea))
@@ -274,7 +271,7 @@ namespace MapAssist.Helpers
                         var label = Utils.GetPortalName(destinationArea, _gameData.Difficulty, playerName);
 
                         if (string.IsNullOrWhiteSpace(label) || label == "None") continue;
-                        drawPoiLabels.Add((MapAssistConfiguration.Loaded.MapConfiguration.Portal, gameObject.Position, label, null));
+                        DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Portal, gameObject.Position, label);
                     }
 
                     continue;
@@ -286,7 +283,7 @@ namespace MapAssist.Helpers
                     {
                         if (MapAssistConfiguration.Loaded.MapConfiguration.TrappedChest.CanDrawIcon())
                         {
-                            drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.TrappedChest, gameObject.Position));
+                            DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.TrappedChest, gameObject.Position);
                         }
                     }
 
@@ -294,70 +291,15 @@ namespace MapAssist.Helpers
                     {
                         if (MapAssistConfiguration.Loaded.MapConfiguration.LockedChest.CanDrawIcon())
                         {
-                            drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.LockedChest, gameObject.Position));
+                            DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.LockedChest, gameObject.Position);
                         }
                     }
                     else
                     {
                         if (MapAssistConfiguration.Loaded.MapConfiguration.NormalChest.CanDrawIcon())
                         {
-                            drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.NormalChest, gameObject.Position));
+                            DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.NormalChest, gameObject.Position);
                         }
-                    }
-                }
-            }
-
-            // POI icons rendering order (draws after unlisted)
-            var poiRenderingOrder = new IconRendering[]
-            {
-                MapAssistConfiguration.Loaded.MapConfiguration.SuperChest,
-                MapAssistConfiguration.Loaded.MapConfiguration.NormalChest,
-                MapAssistConfiguration.Loaded.MapConfiguration.LockedChest,
-                MapAssistConfiguration.Loaded.MapConfiguration.TrappedChest,
-                MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack,
-                MapAssistConfiguration.Loaded.MapConfiguration.Shrine,
-                MapAssistConfiguration.Loaded.MapConfiguration.Waypoint,
-                MapAssistConfiguration.Loaded.MapConfiguration.Portal,
-            };
-
-            // Draw POI icons (not listed in poiRenderingOrder)
-            foreach ((var rendering, var position) in drawPoiIcons)
-            {
-                if (!poiRenderingOrder.Contains(rendering))
-                {
-                    DrawIcon(gfx, rendering, position);
-                }
-            }
-
-            // Draw POI icons (order by poiRenderingOrder list)
-            foreach (var poiRender in poiRenderingOrder)
-            {
-                foreach ((var rendering, var position) in drawPoiIcons)
-                {
-                    if (poiRender == rendering)
-                    {
-                        DrawIcon(gfx, rendering, position);
-                    }
-                }
-            }
-
-            // Draw POI labels (not listed in poiRenderingOrder)
-            foreach ((var rendering, var position, var text, Color? color) in drawPoiLabels)
-            {
-                if (!poiRenderingOrder.Contains(rendering))
-                {
-                    DrawText(gfx, rendering, position, text, color);
-                }
-            }
-
-            // Draw POI labels (order by poiRenderingOrder list)
-            foreach (var poiRender in poiRenderingOrder)
-            {
-                foreach ((var rendering, var position, var text, Color? color) in drawPoiLabels)
-                {
-                    if (poiRender == rendering)
-                    {
-                        DrawText(gfx, rendering, position, text, color);
                     }
                 }
             }

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -188,6 +188,9 @@ namespace MapAssist.Helpers
 
         private void DrawPointsOfInterest(Graphics gfx)
         {
+            var drawPoiIcons = new HashSet<(IconRendering, Point)>();
+            var drawPoiLabels = new HashSet<(PointOfInterestRendering, Point, string, Color?)>();
+
             foreach (var poi in _pointsOfInterest)
             {
                 if (poi.PoiMatchesPortal(_gameData.Objects, _gameData.Difficulty))
@@ -197,7 +200,7 @@ namespace MapAssist.Helpers
 
                 if (poi.RenderingSettings.CanDrawIcon())
                 {
-                    DrawIcon(gfx, poi.RenderingSettings, poi.Position);
+                    drawPoiIcons.Add((poi.RenderingSettings, poi.Position));
                 }
             }
 
@@ -225,11 +228,11 @@ namespace MapAssist.Helpers
                     if (poi.RenderingSettings.CanDrawLine() && poi.RenderingSettings.CanDrawLabel())
                     {
                         var poiPosition = MovePointInBounds(poi.Position, _gameData.PlayerPosition);
-                        DrawText(gfx, poi.RenderingSettings, poiPosition, poi.Label);
+                        drawPoiLabels.Add((poi.RenderingSettings, poiPosition, poi.Label, null));
                     }
                     else if (poi.RenderingSettings.CanDrawLabel())
                     {
-                        DrawText(gfx, poi.RenderingSettings, poi.Position, poi.Label);
+                        drawPoiLabels.Add((poi.RenderingSettings, poi.Position, poi.Label, null));
                     }
                 }
             }
@@ -244,13 +247,13 @@ namespace MapAssist.Helpers
                 {
                     if (MapAssistConfiguration.Loaded.MapConfiguration.Shrine.CanDrawIcon())
                     {
-                        DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Shrine, gameObject.Position);
+                        drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.Shrine, gameObject.Position));
                     }
 
                     if (MapAssistConfiguration.Loaded.MapConfiguration.Shrine.CanDrawLabel())
                     {
                         var label = Shrine.ShrineDisplayName(gameObject);
-                        DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Shrine, gameObject.Position, label);
+                        drawPoiLabels.Add((MapAssistConfiguration.Loaded.MapConfiguration.Shrine, gameObject.Position, label, null));
                     }
 
                     continue;
@@ -262,7 +265,7 @@ namespace MapAssist.Helpers
 
                     if (MapAssistConfiguration.Loaded.MapConfiguration.Portal.CanDrawIcon())
                     {
-                        DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Portal, gameObject.Position);
+                        drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.Portal, gameObject.Position));
                     }
 
                     if (MapAssistConfiguration.Loaded.MapConfiguration.Portal.CanDrawLabel(destinationArea))
@@ -271,7 +274,7 @@ namespace MapAssist.Helpers
                         var label = Utils.GetPortalName(destinationArea, _gameData.Difficulty, playerName);
 
                         if (string.IsNullOrWhiteSpace(label) || label == "None") continue;
-                        DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Portal, gameObject.Position, label);
+                        drawPoiLabels.Add((MapAssistConfiguration.Loaded.MapConfiguration.Portal, gameObject.Position, label, null));
                     }
 
                     continue;
@@ -283,7 +286,7 @@ namespace MapAssist.Helpers
                     {
                         if (MapAssistConfiguration.Loaded.MapConfiguration.TrappedChest.CanDrawIcon())
                         {
-                            DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.TrappedChest, gameObject.Position);
+                            drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.TrappedChest, gameObject.Position));
                         }
                     }
 
@@ -291,15 +294,70 @@ namespace MapAssist.Helpers
                     {
                         if (MapAssistConfiguration.Loaded.MapConfiguration.LockedChest.CanDrawIcon())
                         {
-                            DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.LockedChest, gameObject.Position);
+                            drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.LockedChest, gameObject.Position));
                         }
                     }
                     else
                     {
                         if (MapAssistConfiguration.Loaded.MapConfiguration.NormalChest.CanDrawIcon())
                         {
-                            DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.NormalChest, gameObject.Position);
+                            drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.NormalChest, gameObject.Position));
                         }
+                    }
+                }
+            }
+
+            // POI icons rendering order (draws after unlisted)
+            var poiRenderingOrder = new IconRendering[]
+            {
+                MapAssistConfiguration.Loaded.MapConfiguration.SuperChest,
+                MapAssistConfiguration.Loaded.MapConfiguration.NormalChest,
+                MapAssistConfiguration.Loaded.MapConfiguration.LockedChest,
+                MapAssistConfiguration.Loaded.MapConfiguration.TrappedChest,
+                MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack,
+                MapAssistConfiguration.Loaded.MapConfiguration.Shrine,
+                MapAssistConfiguration.Loaded.MapConfiguration.Waypoint,
+                MapAssistConfiguration.Loaded.MapConfiguration.Portal,
+            };
+
+            // Draw POI icons (not listed in poiRenderingOrder)
+            foreach ((var rendering, var position) in drawPoiIcons)
+            {
+                if (!poiRenderingOrder.Contains(rendering))
+                {
+                    DrawIcon(gfx, rendering, position);
+                }
+            }
+
+            // Draw POI icons (order by poiRenderingOrder list)
+            foreach (var poiRender in poiRenderingOrder)
+            {
+                foreach ((var rendering, var position) in drawPoiIcons)
+                {
+                    if (poiRender == rendering)
+                    {
+                        DrawIcon(gfx, rendering, position);
+                    }
+                }
+            }
+
+            // Draw POI labels (not listed in poiRenderingOrder)
+            foreach ((var rendering, var position, var text, Color? color) in drawPoiLabels)
+            {
+                if (!poiRenderingOrder.Contains(rendering))
+                {
+                    DrawText(gfx, rendering, position, text, color);
+                }
+            }
+
+            // Draw POI labels (order by poiRenderingOrder list)
+            foreach (var poiRender in poiRenderingOrder)
+            {
+                foreach ((var rendering, var position, var text, Color? color) in drawPoiLabels)
+                {
+                    if (poiRender == rendering)
+                    {
+                        DrawText(gfx, rendering, position, text, color);
                     }
                 }
             }
@@ -307,36 +365,57 @@ namespace MapAssist.Helpers
 
         private void DrawMonsters(Graphics gfx)
         {
+            var drawMonsterIcons = new HashSet<(IconRendering, Types.UnitAny)>();
+            var drawMonsterLabels = new HashSet<(PointOfInterestRendering, Point, string, Color?)>();
+
             RenderTarget renderTarget = gfx.GetRenderTarget();
 
+            foreach (var unitAny in _gameData.Monsters)
+            {
+                var mobRender = GetMonsterIconRendering(unitAny.MonsterData);
+
+                if (AreaExtensions.IsTown(_areaData.Area))
+                {
+                    var npc = (Npc)unitAny.TxtFileNo;
+                    if (NpcExtensions.IsTownsfolk(npc))
+                    {
+                        var rendering = MapAssistConfiguration.Loaded.MapConfiguration.Npc;
+                        if (rendering.CanDrawIcon())
+                        {
+                            drawMonsterIcons.Add((rendering, unitAny));
+                            if (rendering.CanDrawLabel())
+                            {
+                                drawMonsterLabels.Add((rendering, unitAny.Position, NpcExtensions.Name(npc), rendering.LabelColor));
+                            }
+                        }
+                    }
+                }
+                else if (mobRender.CanDrawIcon())
+                {
+                    drawMonsterIcons.Add((mobRender, unitAny));
+                }
+            }
+
+            // All Monster icons must be listed here for rendering
             var monsterRenderingOrder = new IconRendering[]
             {
+                MapAssistConfiguration.Loaded.MapConfiguration.Npc,
                 MapAssistConfiguration.Loaded.MapConfiguration.NormalMonster,
-                MapAssistConfiguration.Loaded.MapConfiguration.EliteMonster,
+                MapAssistConfiguration.Loaded.MapConfiguration.MinionMonster,
+                MapAssistConfiguration.Loaded.MapConfiguration.ChampionMonster,
                 MapAssistConfiguration.Loaded.MapConfiguration.UniqueMonster,
                 MapAssistConfiguration.Loaded.MapConfiguration.SuperUniqueMonster,
             };
 
             foreach (var mobRender in monsterRenderingOrder)
             {
-                foreach (var unitAny in _gameData.Monsters)
+                foreach ((var rendering, var unitAny) in drawMonsterIcons)
                 {
-                    if (mobRender == GetMonsterIconRendering(unitAny.MonsterData) && mobRender.CanDrawIcon())
+                    if (mobRender == rendering)
                     {
                         var monsterPosition = unitAny.Position;
 
-                        DrawIcon(gfx, mobRender, monsterPosition);
-                    }
-                }
-            }
-
-            foreach (var mobRender in monsterRenderingOrder)
-            {
-                foreach (var unitAny in _gameData.Monsters)
-                {
-                    if (mobRender == GetMonsterIconRendering(unitAny.MonsterData) && mobRender.CanDrawIcon())
-                    {
-                        var monsterPosition = unitAny.Position;
+                        DrawIcon(gfx, rendering, monsterPosition);
 
                         // Draw Monster Immunities on top of monster icon
                         var iCount = unitAny.Immunities.Count;
@@ -349,7 +428,7 @@ namespace MapAssist.Helpers
 
                             var iconShape = GetIconShape(mobRender).ToRectangle();
 
-                            var ellipseSize = Math.Max(iconShape.Height / 12, 3 / scaleWidth); // Arbirarily set to be a fraction of the the mob icon size. The important point is that it scales with the mob icon consistently.
+                            var ellipseSize = Math.Max(iconShape.Height / 25, 5 / scaleWidth); // Arbirarily set to be a fraction of the the mob icon size. The important point is that it scales with the mob icon consistently.
                             var dx = ellipseSize * scaleWidth * 1.5f; // Amount of space each indicator will take up, including spacing
 
                             var iX = -dx * (iCount - 1) / 2f; // Moves the first indicator sufficiently left so that the whole group of indicators will be centered.
@@ -373,10 +452,24 @@ namespace MapAssist.Helpers
                     }
                 }
             }
+
+            foreach (var mobRender in monsterRenderingOrder)
+            {
+                foreach ((var rendering, var position, var text, Color? color) in drawMonsterLabels)
+                {
+                    if (mobRender == rendering)
+                    {
+                        DrawText(gfx, rendering, position, text, color);
+                    }
+                }
+            }
         }
 
         private void DrawItems(Graphics gfx)
         {
+            var drawItemIcons = new HashSet<(IconRendering, Point)>();
+            var drawItemLabels = new HashSet<(PointOfInterestRendering, Point, string, Color?)>();
+
             if (MapAssistConfiguration.Loaded.ItemLog.Enabled)
             {
                 foreach (var item in _gameData.Items)
@@ -391,7 +484,7 @@ namespace MapAssist.Helpers
                         var itemPosition = item.Position;
                         var render = MapAssistConfiguration.Loaded.MapConfiguration.Item;
 
-                        DrawIcon(gfx, render, itemPosition);
+                        drawItemIcons.Add((render, itemPosition));
                     }
                 }
 
@@ -413,16 +506,28 @@ namespace MapAssist.Helpers
                                 color = Items.ItemColors[ItemQuality.CRAFT];
                             }
 
-                            DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Item, item.Position, itemBaseName,
-                                color: color);
+                            drawItemLabels.Add((MapAssistConfiguration.Loaded.MapConfiguration.Item, item.Position, itemBaseName, color));
                         }
                     }
                 }
+            }
+
+            foreach ((var rendering, var position) in drawItemIcons)
+            {
+                DrawIcon(gfx, rendering, position);
+            }
+
+            foreach ((var rendering, var position, var text, Color? color) in drawItemLabels)
+            {
+                DrawText(gfx, rendering, position, text, color);
             }
         }
 
         private void DrawPlayers(Graphics gfx)
         {
+            var drawPlayerIcons = new HashSet<(IconRendering, Point)>();
+            var drawPlayerLabels = new HashSet<(PointOfInterestRendering, Point, string, Color?)>();
+
             var areasToRender = new AreaData[] { _areaData };
             if (AreaExtensions.RequiresStitching(_areaData.Area))
             {
@@ -430,7 +535,7 @@ namespace MapAssist.Helpers
             }
 
             Dictionary<uint, Types.UnitAny> corpseList;
-            foreach(var player in _gameData.Players.Values)
+            foreach (var player in _gameData.Players.Values)
             {
                 if (player.IsCorpse && player.UnitId != _gameData.PlayerUnit.UnitId)
                 {
@@ -447,11 +552,11 @@ namespace MapAssist.Helpers
 
             if (GameMemory.Corpses.TryGetValue(_gameData.ProcessId, out corpseList) && corpseList.Values.Count > 0)
             {
-                var canDrawLabel = MapAssistConfiguration.Loaded.MapConfiguration.Corpse.CanDrawLabel();
-                var canDrawIcon = MapAssistConfiguration.Loaded.MapConfiguration.Corpse.CanDrawIcon();
-                var canDrawLine = MapAssistConfiguration.Loaded.MapConfiguration.Corpse.CanDrawLine();
+                var rendering = MapAssistConfiguration.Loaded.MapConfiguration.Corpse;
+                var canDrawLabel = rendering.CanDrawLabel();
+                var canDrawIcon = rendering.CanDrawIcon();
+                var canDrawLine = rendering.CanDrawLine();
                 var corpses = corpseList.Values.ToArray();
-
                 foreach (var corpse in corpses)
                 {
                     if (corpse.Act.ActId != _gameData.PlayerUnit.Act.ActId) continue; // Don't show corpse if not in the same act
@@ -459,22 +564,19 @@ namespace MapAssist.Helpers
 
                     if (canDrawIcon)
                     {
-                        DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Corpse, corpse.Position);
+                        drawPlayerIcons.Add((rendering, corpse.Position));
                     }
-
                     if (canDrawLabel)
                     {
                         var poiPosition = MovePointInBounds(corpse.Position, _gameData.PlayerPosition);
-                        DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Corpse, poiPosition, corpse.Name + " (" + "Corpse" + ")"); //fix label when language is merged in
+                        drawPlayerLabels.Add((rendering, poiPosition, corpse.Name + " (Corpse)", null)); //fix label when language is merged in
                     }
-
                     if (canDrawLine && corpse.Name == _gameData.PlayerUnit.Name)
                     {
-                        var padding = canDrawLabel ? MapAssistConfiguration.Loaded.MapConfiguration.Corpse.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
+                        var padding = canDrawLabel ? rendering.LabelFontSize * 1.44f / 2 : 0; // 1.44f is the line height adjustment
                         var poiPosition = MovePointInBounds(corpse.Position, _gameData.PlayerPosition, padding);
-                        DrawLine(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Corpse, _gameData.PlayerPosition, poiPosition);
+                        DrawLine(gfx, rendering, _gameData.PlayerPosition, poiPosition);
                     }
-
                     if (_gameData.PlayerUnit.DistanceTo(corpse.Position) <= 40)
                     {
                         if (!_gameData.Players.TryGetValue(corpse.UnitId, out var player))
@@ -487,17 +589,14 @@ namespace MapAssist.Helpers
 
             if (_gameData.Roster.EntriesByUnitId.TryGetValue(_gameData.PlayerUnit.UnitId, out var myPlayerEntry))
             {
-                var canDrawIcon = MapAssistConfiguration.Loaded.MapConfiguration.Player.CanDrawIcon();
-                var canDrawLabel = MapAssistConfiguration.Loaded.MapConfiguration.Player.CanDrawLabel();
-                var canDrawNonPartyIcon = MapAssistConfiguration.Loaded.MapConfiguration.NonPartyPlayer.CanDrawIcon();
-                var canDrawNonPartyLabel = MapAssistConfiguration.Loaded.MapConfiguration.NonPartyPlayer.CanDrawLabel();
-                var canDrawHostileLine = MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.CanDrawLine();
-                
                 foreach (var player in _gameData.Roster.List)
                 {
                     var myPlayer = player.UnitId == myPlayerEntry.UnitId;
                     var inMyParty = player.PartyID == myPlayerEntry.PartyID;
                     var playerName = player.Name;
+
+                    var canDrawIcon = MapAssistConfiguration.Loaded.MapConfiguration.Player.CanDrawIcon();
+                    var canDrawLabel = MapAssistConfiguration.Loaded.MapConfiguration.Player.CanDrawLabel();
 
                     if (_gameData.Players.TryGetValue(player.UnitId, out var playerUnit))
                     {
@@ -507,53 +606,52 @@ namespace MapAssist.Helpers
                         // use data from the unit table if available
                         if (playerUnit.InPlayerParty) // partyid is max if player is not in a party
                         {
-                            if (canDrawIcon)
+                            var rendering = myPlayer
+                                ? MapAssistConfiguration.Loaded.MapConfiguration.Player
+                                : MapAssistConfiguration.Loaded.MapConfiguration.PartyPlayer;
+
+                            var canDrawThisIcon = myPlayer
+                                ? canDrawIcon
+                                : MapAssistConfiguration.Loaded.MapConfiguration.PartyPlayer.CanDrawIcon();
+
+                            if (canDrawThisIcon)
                             {
-                                DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Player, playerUnit.Position);
+                                drawPlayerIcons.Add((rendering, playerUnit.Position));
                             }
-                            if (canDrawLabel && !myPlayer)
+
+                            var canDrawThisLabel = myPlayer
+                                ? canDrawLabel
+                                : MapAssistConfiguration.Loaded.MapConfiguration.PartyPlayer.CanDrawLabel();
+
+                            if (canDrawThisLabel && !myPlayer)
                             {
-                                DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Player, playerUnit.Position, playerName,
-                                    color: MapAssistConfiguration.Loaded.MapConfiguration.Player.LabelColor);
+                                drawPlayerLabels.Add((rendering, playerUnit.Position, playerName, rendering.LabelColor));
                             }
                         }
                         else
                         {
-                            if (!myPlayer)
+                            // not in my party
+                            var rendering = (myPlayer
+                                ? MapAssistConfiguration.Loaded.MapConfiguration.Player
+                                : (playerUnit.HostileToPlayer
+                                    ? MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer
+                                    : MapAssistConfiguration.Loaded.MapConfiguration.NonPartyPlayer));
+
+                            if (rendering.CanDrawIcon())
                             {
-                                if (canDrawNonPartyIcon)
-                                {
-                                    if (playerUnit.HostileToPlayer)
-                                    {
-                                        DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer, playerUnit.Position); //not my player and not in my party + hostile
-                                    } else
-                                    {
-                                        DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.NonPartyPlayer, playerUnit.Position); //not my player and not in my party
-                                    }
-                                }
-                                if(canDrawHostileLine && playerUnit.HostileToPlayer)
-                                {
-                                    var padding = canDrawNonPartyLabel ? MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
-                                    var poiPosition = MovePointInBounds(playerUnit.Position, _gameData.PlayerPosition, padding);
-                                    DrawLine(gfx, MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer, _gameData.PlayerPosition, poiPosition);
-                                }
-                            }
-                            else if (canDrawIcon)
-                            {
-                                DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Player, playerUnit.Position); //my player
+                                drawPlayerIcons.Add((rendering, playerUnit.Position));
                             }
 
-                            if (canDrawNonPartyLabel && !myPlayer)
+                            if (rendering.CanDrawLine() && playerUnit.HostileToPlayer)
                             {
-                                if (playerUnit.HostileToPlayer)
-                                {
-                                    DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer, playerUnit.Position, playerName,
-                                        color: MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.LabelColor);
-                                } else
-                                {
-                                    DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.NonPartyPlayer, playerUnit.Position, playerName,
-                                        color: MapAssistConfiguration.Loaded.MapConfiguration.NonPartyPlayer.LabelColor);
-                                }
+                                var padding = rendering.CanDrawLabel() ? MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.LabelFontSize * 1.44f / 2 : 0; // 1.44f is the line height adjustment
+                                var poiPosition = MovePointInBounds(playerUnit.Position, _gameData.PlayerPosition, padding);
+                                DrawLine(gfx, MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer, _gameData.PlayerPosition, poiPosition);
+                            }
+
+                            if (rendering.CanDrawLabel() && !myPlayer)
+                            {
+                                drawPlayerLabels.Add((rendering, playerUnit.Position, playerName, rendering.LabelColor));
                             }
                         }
                     }
@@ -565,17 +663,49 @@ namespace MapAssist.Helpers
                         // only draw if in the same party, otherwise position/area data will not be up to date
                         if (inMyParty && player.PartyID < ushort.MaxValue)
                         {
+                            var rendering = MapAssistConfiguration.Loaded.MapConfiguration.PartyPlayer;
                             if (canDrawIcon)
                             {
-                                DrawIcon(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Player, player.Position);
+                                drawPlayerIcons.Add((rendering, player.Position));
                             }
 
                             if (canDrawLabel && !myPlayer)
                             {
-                                DrawText(gfx, MapAssistConfiguration.Loaded.MapConfiguration.Player, player.Position, playerName,
-                                    color: MapAssistConfiguration.Loaded.MapConfiguration.Player.LabelColor);
+                                drawPlayerLabels.Add((rendering, player.Position, playerName, rendering.LabelColor));
                             }
                         }
+                    }
+                }
+            }
+
+            // All Player icons must be listed here for rendering
+            var playersRenderingOrder = new IconRendering[]
+            {
+                MapAssistConfiguration.Loaded.MapConfiguration.Corpse,
+                MapAssistConfiguration.Loaded.MapConfiguration.NonPartyPlayer,
+                MapAssistConfiguration.Loaded.MapConfiguration.PartyPlayer,
+                MapAssistConfiguration.Loaded.MapConfiguration.Player,
+                MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer,
+            };
+
+            foreach (var renderOrder in playersRenderingOrder)
+            {
+                foreach ((var rendering, var position) in drawPlayerIcons)
+                {
+                    if (renderOrder == rendering)
+                    {
+                        DrawIcon(gfx, rendering, position);
+                    }
+                }
+            }
+
+            foreach (var renderOrder in playersRenderingOrder)
+            {
+                foreach ((var rendering, var position, var text, Color? color) in drawPlayerLabels)
+                {
+                    if (renderOrder == rendering)
+                    {
+                        DrawText(gfx, rendering, position, text, color);
                     }
                 }
             }
@@ -1046,19 +1176,24 @@ namespace MapAssist.Helpers
 
         private IconRendering GetMonsterIconRendering(MonsterData monsterData)
         {
+            if ((monsterData.MonsterType & MonsterTypeFlags.Champion) == MonsterTypeFlags.Champion)
+            {
+                return MapAssistConfiguration.Loaded.MapConfiguration.ChampionMonster;
+            }
+
             if ((monsterData.MonsterType & MonsterTypeFlags.SuperUnique) == MonsterTypeFlags.SuperUnique)
             {
                 return MapAssistConfiguration.Loaded.MapConfiguration.SuperUniqueMonster;
             }
 
+            if ((monsterData.MonsterType & MonsterTypeFlags.Minion) == MonsterTypeFlags.Minion)
+            {
+                return MapAssistConfiguration.Loaded.MapConfiguration.MinionMonster;
+            }
+
             if ((monsterData.MonsterType & MonsterTypeFlags.Unique) == MonsterTypeFlags.Unique)
             {
                 return MapAssistConfiguration.Loaded.MapConfiguration.UniqueMonster;
-            }
-
-            if (monsterData.MonsterType > 0)
-            {
-                return MapAssistConfiguration.Loaded.MapConfiguration.EliteMonster;
             }
 
             return MapAssistConfiguration.Loaded.MapConfiguration.NormalMonster;

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -374,23 +374,7 @@ namespace MapAssist.Helpers
             {
                 var mobRender = GetMonsterIconRendering(unitAny.MonsterData);
 
-                if (AreaExtensions.IsTown(_areaData.Area))
-                {
-                    var npc = (Npc)unitAny.TxtFileNo;
-                    if (NpcExtensions.IsTownsfolk(npc))
-                    {
-                        var rendering = MapAssistConfiguration.Loaded.MapConfiguration.Npc;
-                        if (rendering.CanDrawIcon())
-                        {
-                            drawMonsterIcons.Add((rendering, unitAny));
-                            if (rendering.CanDrawLabel())
-                            {
-                                drawMonsterLabels.Add((rendering, unitAny.Position, NpcExtensions.Name(npc), rendering.LabelColor));
-                            }
-                        }
-                    }
-                }
-                else if (mobRender.CanDrawIcon())
+                if (mobRender.CanDrawIcon())
                 {
                     drawMonsterIcons.Add((mobRender, unitAny));
                 }
@@ -399,7 +383,6 @@ namespace MapAssist.Helpers
             // All Monster icons must be listed here for rendering
             var monsterRenderingOrder = new IconRendering[]
             {
-                MapAssistConfiguration.Loaded.MapConfiguration.Npc,
                 MapAssistConfiguration.Loaded.MapConfiguration.NormalMonster,
                 MapAssistConfiguration.Loaded.MapConfiguration.MinionMonster,
                 MapAssistConfiguration.Loaded.MapConfiguration.ChampionMonster,

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -411,7 +411,7 @@ namespace MapAssist.Helpers
 
                             var iconShape = GetIconShape(mobRender).ToRectangle();
 
-                            var ellipseSize = Math.Max(iconShape.Height / 25, 5 / scaleWidth); // Arbirarily set to be a fraction of the the mob icon size. The important point is that it scales with the mob icon consistently.
+                            var ellipseSize = Math.Max(iconShape.Height / 12, 3 / scaleWidth); // Arbirarily set to be a fraction of the the mob icon size. The important point is that it scales with the mob icon consistently.
                             var dx = ellipseSize * scaleWidth * 1.5f; // Amount of space each indicator will take up, including spacing
 
                             var iX = -dx * (iCount - 1) / 2f; // Moves the first indicator sufficiently left so that the whole group of indicators will be centered.
@@ -556,7 +556,7 @@ namespace MapAssist.Helpers
                     }
                     if (canDrawLine && corpse.Name == _gameData.PlayerUnit.Name)
                     {
-                        var padding = canDrawLabel ? rendering.LabelFontSize * 1.44f / 2 : 0; // 1.44f is the line height adjustment
+                        var padding = canDrawLabel ? rendering.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
                         var poiPosition = MovePointInBounds(corpse.Position, _gameData.PlayerPosition, padding);
                         DrawLine(gfx, rendering, _gameData.PlayerPosition, poiPosition);
                     }
@@ -627,7 +627,7 @@ namespace MapAssist.Helpers
 
                             if (rendering.CanDrawLine() && playerUnit.HostileToPlayer)
                             {
-                                var padding = rendering.CanDrawLabel() ? MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.LabelFontSize * 1.44f / 2 : 0; // 1.44f is the line height adjustment
+                                var padding = rendering.CanDrawLabel() ? MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
                                 var poiPosition = MovePointInBounds(playerUnit.Position, _gameData.PlayerPosition, padding);
                                 DrawLine(gfx, MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer, _gameData.PlayerPosition, poiPosition);
                             }

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -188,8 +188,8 @@ namespace MapAssist.Helpers
 
         private void DrawPointsOfInterest(Graphics gfx)
         {
-            var drawPoiIcons = new List<(IconRendering, Point)>() { };
-            var drawPoiLabels = new List<(PointOfInterestRendering, Point, string, Color?)>() { };
+            var drawPoiIcons = new List<(IconRendering, Point)>();
+            var drawPoiLabels = new List<(PointOfInterestRendering, Point, string, Color?)>();
 
             foreach (var poi in _pointsOfInterest)
             {
@@ -322,7 +322,7 @@ namespace MapAssist.Helpers
 
         private void DrawMonsters(Graphics gfx)
         {
-            var drawMonsterIcons = new List<(IconRendering, Types.UnitAny)>() { };
+            var drawMonsterIcons = new List<(IconRendering, Types.UnitAny)>();
 
             RenderTarget renderTarget = gfx.GetRenderTarget();
 
@@ -395,8 +395,8 @@ namespace MapAssist.Helpers
 
         private void DrawItems(Graphics gfx)
         {
-            var drawItemIcons = new List<(IconRendering, Point)>() { };
-            var drawItemLabels = new List<(PointOfInterestRendering, Point, string, Color?)>() { };
+            var drawItemIcons = new List<(IconRendering, Point)>();
+            var drawItemLabels = new List<(PointOfInterestRendering, Point, string, Color?)>();
 
             if (MapAssistConfiguration.Loaded.ItemLog.Enabled)
             {
@@ -453,8 +453,8 @@ namespace MapAssist.Helpers
 
         private void DrawPlayers(Graphics gfx)
         {
-            var drawPlayerIcons = new List<(IconRendering rendering, Point position)>() { };
-            var drawPlayerLabels = new List<(PointOfInterestRendering rendering, Point position, string label, Color? color)>() { };
+            var drawPlayerIcons = new List<(IconRendering, Point)>();
+            var drawPlayerLabels = new List<(PointOfInterestRendering, Point, string, Color?)>();
 
             var areasToRender = new AreaData[] { _areaData };
             if (AreaExtensions.RequiresStitching(_areaData.Area))

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -188,8 +188,8 @@ namespace MapAssist.Helpers
 
         private void DrawPointsOfInterest(Graphics gfx)
         {
-            var drawPoiIcons = new HashSet<(IconRendering, Point)>();
-            var drawPoiLabels = new HashSet<(PointOfInterestRendering, Point, string, Color?)>();
+            var drawPoiIcons = new List<(IconRendering, Point)>() { };
+            var drawPoiLabels = new List<(PointOfInterestRendering, Point, string, Color?)>() { };
 
             foreach (var poi in _pointsOfInterest)
             {
@@ -322,7 +322,7 @@ namespace MapAssist.Helpers
 
         private void DrawMonsters(Graphics gfx)
         {
-            var drawMonsterIcons = new HashSet<(IconRendering, Types.UnitAny)>();
+            var drawMonsterIcons = new List<(IconRendering, Types.UnitAny)>() { };
 
             RenderTarget renderTarget = gfx.GetRenderTarget();
 
@@ -395,8 +395,8 @@ namespace MapAssist.Helpers
 
         private void DrawItems(Graphics gfx)
         {
-            var drawItemIcons = new HashSet<(IconRendering, Point)>();
-            var drawItemLabels = new HashSet<(PointOfInterestRendering, Point, string, Color?)>();
+            var drawItemIcons = new List<(IconRendering, Point)>() { };
+            var drawItemLabels = new List<(PointOfInterestRendering, Point, string, Color?)>() { };
 
             if (MapAssistConfiguration.Loaded.ItemLog.Enabled)
             {
@@ -453,8 +453,8 @@ namespace MapAssist.Helpers
 
         private void DrawPlayers(Graphics gfx)
         {
-            var drawPlayerIcons = new HashSet<(IconRendering, Point)>();
-            var drawPlayerLabels = new HashSet<(PointOfInterestRendering, Point, string, Color?)>();
+            var drawPlayerIcons = new List<(IconRendering rendering, Point position)>() { };
+            var drawPlayerLabels = new List<(PointOfInterestRendering rendering, Point position, string label, Color? color)>() { };
 
             var areasToRender = new AreaData[] { _areaData };
             if (AreaExtensions.RequiresStitching(_areaData.Area))

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -91,13 +91,21 @@ namespace MapAssist.Settings
         public IconRendering UniqueMonster { get; set; }
         public static IconRendering UniqueMonsterREF => MapAssistConfiguration.Loaded.MapConfiguration.UniqueMonster;
 
-        [YamlMember(Alias = "EliteMonster", ApplyNamingConventions = false)]
-        public IconRendering EliteMonster { get; set; }
-        public static IconRendering EliteMonsterREF => MapAssistConfiguration.Loaded.MapConfiguration.EliteMonster;
+        [YamlMember(Alias = "ChampionMonster", ApplyNamingConventions = false)]
+        public IconRendering ChampionMonster { get; set; }
+        public static IconRendering ChampionMonsterREF => MapAssistConfiguration.Loaded.MapConfiguration.ChampionMonster;
+
+        [YamlMember(Alias = "MinionMonster", ApplyNamingConventions = false)]
+        public IconRendering MinionMonster { get; set; }
+        public static IconRendering MinionMonsterREF => MapAssistConfiguration.Loaded.MapConfiguration.MinionMonster;
 
         [YamlMember(Alias = "NormalMonster", ApplyNamingConventions = false)]
         public IconRendering NormalMonster { get; set; }
         public static IconRendering NormalMonsterREF => MapAssistConfiguration.Loaded.MapConfiguration.NormalMonster;
+
+        [YamlMember(Alias = "Npc", ApplyNamingConventions = false)]
+        public PointOfInterestRendering Npc { get; set; }
+        public static IconRendering NpcREF => MapAssistConfiguration.Loaded.MapConfiguration.Npc;
 
         [YamlMember(Alias = "NextArea", ApplyNamingConventions = false)]
         public PointOfInterestRendering NextArea { get; set; }
@@ -118,6 +126,10 @@ namespace MapAssist.Settings
         [YamlMember(Alias = "Player", ApplyNamingConventions = false)]
         public PointOfInterestRendering Player { get; set; }
         public static PointOfInterestRendering PlayerREF => MapAssistConfiguration.Loaded.MapConfiguration.Player;
+
+        [YamlMember(Alias = "NonPartyPlayer", ApplyNamingConventions = false)]
+        public PointOfInterestRendering PartyPlayer { get; set; }
+        public static PointOfInterestRendering PartyPlayerREF => MapAssistConfiguration.Loaded.MapConfiguration.PartyPlayer;
 
         [YamlMember(Alias = "NonPartyPlayer", ApplyNamingConventions = false)]
         public PointOfInterestRendering NonPartyPlayer { get; set; }

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -103,10 +103,6 @@ namespace MapAssist.Settings
         public IconRendering NormalMonster { get; set; }
         public static IconRendering NormalMonsterREF => MapAssistConfiguration.Loaded.MapConfiguration.NormalMonster;
 
-        [YamlMember(Alias = "Npc", ApplyNamingConventions = false)]
-        public PointOfInterestRendering Npc { get; set; }
-        public static IconRendering NpcREF => MapAssistConfiguration.Loaded.MapConfiguration.Npc;
-
         [YamlMember(Alias = "NextArea", ApplyNamingConventions = false)]
         public PointOfInterestRendering NextArea { get; set; }
         public static PointOfInterestRendering NextAreaREF => MapAssistConfiguration.Loaded.MapConfiguration.NextArea;
@@ -127,7 +123,7 @@ namespace MapAssist.Settings
         public PointOfInterestRendering Player { get; set; }
         public static PointOfInterestRendering PlayerREF => MapAssistConfiguration.Loaded.MapConfiguration.Player;
 
-        [YamlMember(Alias = "NonPartyPlayer", ApplyNamingConventions = false)]
+        [YamlMember(Alias = "PartyPlayer", ApplyNamingConventions = false)]
         public PointOfInterestRendering PartyPlayer { get; set; }
         public static PointOfInterestRendering PartyPlayerREF => MapAssistConfiguration.Loaded.MapConfiguration.PartyPlayer;
 


### PR DESCRIPTION
This branch changes the rendering order for Icons and Labels in Compositor to ensure that icons are drawn first (in a specified order, useful for icon stacking on Chests for example) and then all icon labels are drawn last.  This is fairly a subtle change now that has a greater affect when icon labels have a text shadow (future PR).
- `DrawPointsOfInterest` - Uses a Render Order for some icons, but will draw icons not listed in the Rendering Order list too
- `DrawMonsters` - All Monster icons must be listed here for rendering
- `DrawPlayers` - All Player icons must be listed here for rendering

New MapConfiguration options:
- `ChampionMonster` - instead of Champion mobs sharing same icon settings as Unique mobs
- `MinionMonster` - instead of calling them "Elite".  Changed DarkRed to lighter Gray color since (let's be honest) they aren't _that_ special and a lighter Gray icon makes it easy to find the Unique or SuperUnique within the pack.
- `PartyPlayer` - now the Player icon can be different than Party Members (similar to in-game map)

### Before pics:
> ![monster-icon-before](https://user-images.githubusercontent.com/10291543/147993456-a3327037-a09e-4c4f-b819-a16f990ecb3f.png)
> champion pack to the left, unique pack to the right

> ![player-icon-before](https://user-images.githubusercontent.com/10291543/147993462-82463f15-08b3-4260-99ae-bd5f3be85bff.png)
> player icon same color as party member

### After pics:
> ![monster-icon-after](https://user-images.githubusercontent.com/10291543/147993468-2d984bee-7da5-405e-872c-a3de09b9f673.png)
> champion pack to the left, unique pack to the right

> ![player-icon-after](https://user-images.githubusercontent.com/10291543/147993469-122cd43c-d49d-43a7-a77b-01e0d0e4d21d.png)
> player icon different color than party member (hostiles, non-partied, and corpses are unchanged)
