### PR TITLE
Text Shadows + GUI updates

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -58,7 +58,7 @@ MapConfiguration:
     LabelColor: 199, 179, 119
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   NextArea:
     IconColor: SpringGreen
     IconShape: Square
@@ -69,7 +69,7 @@ MapConfiguration:
     LabelColor: SpringGreen
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   PreviousArea:
     IconColor: Violet
     IconShape: Square
@@ -77,7 +77,7 @@ MapConfiguration:
     LabelColor: Violet
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   Waypoint:
     IconColor: SteelBlue
     IconShape: Square
@@ -89,7 +89,7 @@ MapConfiguration:
     LabelColor: Tomato
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   Player:
     IconOutlineColor: 33, 136, 253
     IconShape: Cross
@@ -98,7 +98,7 @@ MapConfiguration:
     LabelColor: Chartreuse
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   PartyPlayer:
     IconOutlineColor: Chartreuse
     IconShape: Cross
@@ -107,7 +107,7 @@ MapConfiguration:
     LabelColor: Chartreuse
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   NonPartyPlayer:
     IconOutlineColor: Orange
     IconShape: Cross
@@ -116,7 +116,7 @@ MapConfiguration:
     LabelColor: Orange
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   HostilePlayer:
     IconOutlineColor: Red
     IconShape: Cross
@@ -128,7 +128,7 @@ MapConfiguration:
     LabelColor: Red
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   Corpse:
     IconOutlineColor: Magenta
     IconShape: Cross
@@ -140,7 +140,7 @@ MapConfiguration:
     LabelColor: Magenta
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   Portal:
     IconOutlineColor: Yellow
     IconShape: Portal
@@ -149,7 +149,7 @@ MapConfiguration:
     LabelColor: Yellow
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   SuperChest:
     IconColor: 17, 255, 0
     IconShape: Square
@@ -173,7 +173,7 @@ MapConfiguration:
     LabelColor: 255, 218, 100
     LabelFontSize: 14
     LabelFont: Formal 436
-    LabelFontShadow: true
+    LabelTextShadow: true
   ArmorWeapRack:
     IconColor: 132, 132, 132
     IconShape: Square
@@ -184,7 +184,7 @@ MapConfiguration:
     IconSize: 4
     LabelFontSize: 16
     LabelFont: Exocet Blizzard Mixed Caps
-    LabelFontShadow: true
+    LabelTextShadow: true
 ItemLog:
   Enabled: true
   FilterFileName: ItemFilter.yaml
@@ -194,7 +194,7 @@ ItemLog:
   DisplayForSeconds: 45
   LabelFont: Exocet Blizzard Mixed Caps
   LabelFontSize: 14
-  LabelFontShadow: true
+  LabelTextShadow: true
 MapColorConfiguration:
   Border: 255, 255, 255
 GameInfo:
@@ -204,6 +204,6 @@ GameInfo:
   ShowOverlayFPS: false
   LabelFont: Exocet Blizzard Mixed Caps
   LabelFontSize: 14
-  LabelFontShadow: true
+  LabelTextShadow: true
 D2Path: ''
 LanguageCode: enUS

--- a/Config.yaml
+++ b/Config.yaml
@@ -58,6 +58,7 @@ MapConfiguration:
     LabelColor: 199, 179, 119
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   NextArea:
     IconColor: SpringGreen
     IconShape: Square
@@ -68,6 +69,7 @@ MapConfiguration:
     LabelColor: SpringGreen
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   PreviousArea:
     IconColor: Violet
     IconShape: Square
@@ -75,6 +77,7 @@ MapConfiguration:
     LabelColor: Violet
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   Waypoint:
     IconColor: SteelBlue
     IconShape: Square
@@ -86,6 +89,7 @@ MapConfiguration:
     LabelColor: Tomato
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   Player:
     IconOutlineColor: 33, 136, 253
     IconShape: Cross
@@ -94,6 +98,7 @@ MapConfiguration:
     LabelColor: Chartreuse
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   PartyPlayer:
     IconOutlineColor: Chartreuse
     IconShape: Cross
@@ -102,6 +107,7 @@ MapConfiguration:
     LabelColor: Chartreuse
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   NonPartyPlayer:
     IconOutlineColor: Orange
     IconShape: Cross
@@ -110,6 +116,7 @@ MapConfiguration:
     LabelColor: Orange
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   HostilePlayer:
     IconOutlineColor: Red
     IconShape: Cross
@@ -121,6 +128,7 @@ MapConfiguration:
     LabelColor: Red
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   Corpse:
     IconOutlineColor: Magenta
     IconShape: Cross
@@ -132,6 +140,7 @@ MapConfiguration:
     LabelColor: Magenta
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   Portal:
     IconOutlineColor: Yellow
     IconShape: Portal
@@ -140,6 +149,7 @@ MapConfiguration:
     LabelColor: Yellow
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   SuperChest:
     IconColor: 17, 255, 0
     IconShape: Square
@@ -163,6 +173,7 @@ MapConfiguration:
     LabelColor: 255, 218, 100
     LabelFontSize: 14
     LabelFont: Formal 436
+    LabelFontShadow: true
   ArmorWeapRack:
     IconColor: 132, 132, 132
     IconShape: Square
@@ -173,6 +184,7 @@ MapConfiguration:
     IconSize: 4
     LabelFontSize: 16
     LabelFont: Exocet Blizzard Mixed Caps
+    LabelFontShadow: true
 ItemLog:
   Enabled: true
   FilterFileName: ItemFilter.yaml
@@ -182,6 +194,7 @@ ItemLog:
   DisplayForSeconds: 45
   LabelFont: Exocet Blizzard Mixed Caps
   LabelFontSize: 14
+  LabelFontShadow: true
 MapColorConfiguration:
   Border: 255, 255, 255
 GameInfo:
@@ -191,5 +204,6 @@ GameInfo:
   ShowOverlayFPS: false
   LabelFont: Exocet Blizzard Mixed Caps
   LabelFontSize: 14
+  LabelFontShadow: true
 D2Path: ''
 LanguageCode: enUS

--- a/ConfigEditor.Designer.cs
+++ b/ConfigEditor.Designer.cs
@@ -205,9 +205,9 @@
             this.groupBox5.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.groupBox5.Controls.Add(this.cboLanguage);
             this.groupBox5.Controls.Add(this.label11);
-            this.groupBox5.Location = new System.Drawing.Point(5, 265);
+            this.groupBox5.Location = new System.Drawing.Point(11, 256);
             this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(313, 57);
+            this.groupBox5.Size = new System.Drawing.Size(300, 57);
             this.groupBox5.TabIndex = 25;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "Translation";
@@ -218,7 +218,7 @@
             this.cboLanguage.FormattingEnabled = true;
             this.cboLanguage.Location = new System.Drawing.Point(71, 22);
             this.cboLanguage.Name = "cboLanguage";
-            this.cboLanguage.Size = new System.Drawing.Size(132, 21);
+            this.cboLanguage.Size = new System.Drawing.Size(146, 21);
             this.cboLanguage.TabIndex = 14;
             this.cboLanguage.SelectedIndexChanged += new System.EventHandler(this.cboLanguage_SelectedIndexChanged);
             // 
@@ -237,9 +237,9 @@
             this.groupBox4.Controls.Add(this.txtD2Path);
             this.groupBox4.Controls.Add(this.btnBrowseD2Location);
             this.groupBox4.Controls.Add(this.label1);
-            this.groupBox4.Location = new System.Drawing.Point(5, 179);
+            this.groupBox4.Location = new System.Drawing.Point(11, 151);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(313, 69);
+            this.groupBox4.Size = new System.Drawing.Size(300, 69);
             this.groupBox4.TabIndex = 24;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "D2LoD 1.13c Path";
@@ -249,13 +249,13 @@
             this.txtD2Path.Enabled = false;
             this.txtD2Path.Location = new System.Drawing.Point(10, 23);
             this.txtD2Path.Name = "txtD2Path";
-            this.txtD2Path.Size = new System.Drawing.Size(207, 20);
+            this.txtD2Path.Size = new System.Drawing.Size(201, 20);
             this.txtD2Path.TabIndex = 7;
             this.txtD2Path.TextChanged += new System.EventHandler(this.txtD2Path_TextChanged);
             // 
             // btnBrowseD2Location
             // 
-            this.btnBrowseD2Location.Location = new System.Drawing.Point(225, 21);
+            this.btnBrowseD2Location.Location = new System.Drawing.Point(217, 21);
             this.btnBrowseD2Location.Name = "btnBrowseD2Location";
             this.btnBrowseD2Location.Size = new System.Drawing.Size(75, 23);
             this.btnBrowseD2Location.TabIndex = 17;
@@ -285,9 +285,9 @@
             this.grpGameInfo.Controls.Add(this.chkShowArea);
             this.grpGameInfo.Controls.Add(this.txtHuntIP);
             this.grpGameInfo.Controls.Add(this.label7);
-            this.grpGameInfo.Location = new System.Drawing.Point(5, 4);
+            this.grpGameInfo.Location = new System.Drawing.Point(11, 9);
             this.grpGameInfo.Name = "grpGameInfo";
-            this.grpGameInfo.Size = new System.Drawing.Size(313, 103);
+            this.grpGameInfo.Size = new System.Drawing.Size(300, 103);
             this.grpGameInfo.TabIndex = 23;
             this.grpGameInfo.TabStop = false;
             this.grpGameInfo.Text = "Game Info";
@@ -1458,7 +1458,7 @@
             this.groupBox2.Controls.Add(this.btnRemoveHidden);
             this.groupBox2.Controls.Add(this.btnAddHidden);
             this.groupBox2.Controls.Add(this.lstHidden);
-            this.groupBox2.Location = new System.Drawing.Point(5, 4);
+            this.groupBox2.Location = new System.Drawing.Point(11, 9);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(300, 189);
             this.groupBox2.TabIndex = 2;

--- a/ConfigEditor.Designer.cs
+++ b/ConfigEditor.Designer.cs
@@ -31,16 +31,22 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ConfigEditor));
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage5 = new System.Windows.Forms.TabPage();
-            this.btnBrowseD2Location = new System.Windows.Forms.Button();
-            this.chkShowArea = new System.Windows.Forms.CheckBox();
+            this.groupBox5 = new System.Windows.Forms.GroupBox();
             this.cboLanguage = new System.Windows.Forms.ComboBox();
-            this.label1 = new System.Windows.Forms.Label();
             this.label11 = new System.Windows.Forms.Label();
+            this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.txtD2Path = new System.Windows.Forms.TextBox();
+            this.btnBrowseD2Location = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
+            this.grpGameInfo = new System.Windows.Forms.GroupBox();
+            this.chkGameInfoTextShadow = new System.Windows.Forms.CheckBox();
+            this.btnClearGameInfoFont = new System.Windows.Forms.Button();
+            this.btnGameInfoFont = new System.Windows.Forms.Button();
+            this.chkShowOverlayFPS = new System.Windows.Forms.CheckBox();
             this.chkGameInfo = new System.Windows.Forms.CheckBox();
+            this.chkShowArea = new System.Windows.Forms.CheckBox();
             this.txtHuntIP = new System.Windows.Forms.TextBox();
             this.label7 = new System.Windows.Forms.Label();
-            this.txtD2Path = new System.Windows.Forms.TextBox();
-            this.label6 = new System.Windows.Forms.Label();
             this.tabPage1 = new System.Windows.Forms.TabPage();
             this.panel1 = new System.Windows.Forms.Panel();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
@@ -88,9 +94,9 @@
             this.label9 = new System.Windows.Forms.Label();
             this.cboIconShape = new System.Windows.Forms.ComboBox();
             this.tabLabel = new System.Windows.Forms.TabPage();
+            this.chkTextShadow = new System.Windows.Forms.CheckBox();
             this.btnClearLabelFont = new System.Windows.Forms.Button();
             this.btnClearLabelColor = new System.Windows.Forms.Button();
-            this.label3 = new System.Windows.Forms.Label();
             this.btnFont = new System.Windows.Forms.Button();
             this.btnLabelColor = new System.Windows.Forms.Button();
             this.tabLine = new System.Windows.Forms.TabPage();
@@ -105,12 +111,12 @@
             this.label8 = new System.Windows.Forms.Label();
             this.cboRenderOption = new System.Windows.Forms.ComboBox();
             this.tabPage6 = new System.Windows.Forms.TabPage();
+            this.chkLogTextShadow = new System.Windows.Forms.CheckBox();
             this.btnClearLogFont = new System.Windows.Forms.Button();
             this.lblSoundVolumeValue = new System.Windows.Forms.Label();
             this.soundVolume = new System.Windows.Forms.TrackBar();
             this.label10 = new System.Windows.Forms.Label();
             this.lblItemDisplayForSecondsValue = new System.Windows.Forms.Label();
-            this.label19 = new System.Windows.Forms.Label();
             this.itemDisplayForSeconds = new System.Windows.Forms.TrackBar();
             this.btnLogFont = new System.Windows.Forms.Button();
             this.label21 = new System.Windows.Forms.Label();
@@ -136,10 +142,12 @@
             this.btnRemoveHidden = new System.Windows.Forms.Button();
             this.btnAddHidden = new System.Windows.Forms.Button();
             this.lstHidden = new System.Windows.Forms.ListBox();
-            this.chkShowOverlayFPS = new System.Windows.Forms.CheckBox();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
             this.tabControl1.SuspendLayout();
             this.tabPage5.SuspendLayout();
+            this.groupBox5.SuspendLayout();
+            this.groupBox4.SuspendLayout();
+            this.grpGameInfo.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.panel1.SuspendLayout();
             this.groupBox3.SuspendLayout();
@@ -182,16 +190,9 @@
             // 
             // tabPage5
             // 
-            this.tabPage5.Controls.Add(this.btnBrowseD2Location);
-            this.tabPage5.Controls.Add(this.chkShowArea);
-            this.tabPage5.Controls.Add(this.cboLanguage);
-            this.tabPage5.Controls.Add(this.label1);
-            this.tabPage5.Controls.Add(this.label11);
-            this.tabPage5.Controls.Add(this.chkGameInfo);
-            this.tabPage5.Controls.Add(this.txtHuntIP);
-            this.tabPage5.Controls.Add(this.label7);
-            this.tabPage5.Controls.Add(this.txtD2Path);
-            this.tabPage5.Controls.Add(this.label6);
+            this.tabPage5.Controls.Add(this.groupBox5);
+            this.tabPage5.Controls.Add(this.groupBox4);
+            this.tabPage5.Controls.Add(this.grpGameInfo);
             this.tabPage5.Location = new System.Drawing.Point(4, 22);
             this.tabPage5.Name = "tabPage5";
             this.tabPage5.Size = new System.Drawing.Size(324, 325);
@@ -199,9 +200,62 @@
             this.tabPage5.Text = "Main";
             this.tabPage5.UseVisualStyleBackColor = true;
             // 
+            // groupBox5
+            // 
+            this.groupBox5.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.groupBox5.Controls.Add(this.cboLanguage);
+            this.groupBox5.Controls.Add(this.label11);
+            this.groupBox5.Location = new System.Drawing.Point(5, 265);
+            this.groupBox5.Name = "groupBox5";
+            this.groupBox5.Size = new System.Drawing.Size(313, 57);
+            this.groupBox5.TabIndex = 25;
+            this.groupBox5.TabStop = false;
+            this.groupBox5.Text = "Translation";
+            // 
+            // cboLanguage
+            // 
+            this.cboLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboLanguage.FormattingEnabled = true;
+            this.cboLanguage.Location = new System.Drawing.Point(71, 22);
+            this.cboLanguage.Name = "cboLanguage";
+            this.cboLanguage.Size = new System.Drawing.Size(132, 21);
+            this.cboLanguage.TabIndex = 14;
+            this.cboLanguage.SelectedIndexChanged += new System.EventHandler(this.cboLanguage_SelectedIndexChanged);
+            // 
+            // label11
+            // 
+            this.label11.AutoSize = true;
+            this.label11.Location = new System.Drawing.Point(7, 25);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(58, 13);
+            this.label11.TabIndex = 13;
+            this.label11.Text = "Language:";
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.groupBox4.Controls.Add(this.txtD2Path);
+            this.groupBox4.Controls.Add(this.btnBrowseD2Location);
+            this.groupBox4.Controls.Add(this.label1);
+            this.groupBox4.Location = new System.Drawing.Point(5, 179);
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.Size = new System.Drawing.Size(313, 69);
+            this.groupBox4.TabIndex = 24;
+            this.groupBox4.TabStop = false;
+            this.groupBox4.Text = "D2LoD 1.13c Path";
+            // 
+            // txtD2Path
+            // 
+            this.txtD2Path.Enabled = false;
+            this.txtD2Path.Location = new System.Drawing.Point(10, 23);
+            this.txtD2Path.Name = "txtD2Path";
+            this.txtD2Path.Size = new System.Drawing.Size(207, 20);
+            this.txtD2Path.TabIndex = 7;
+            this.txtD2Path.TextChanged += new System.EventHandler(this.txtD2Path_TextChanged);
+            // 
             // btnBrowseD2Location
             // 
-            this.btnBrowseD2Location.Location = new System.Drawing.Point(236, 110);
+            this.btnBrowseD2Location.Location = new System.Drawing.Point(225, 21);
             this.btnBrowseD2Location.Name = "btnBrowseD2Location";
             this.btnBrowseD2Location.Size = new System.Drawing.Size(75, 23);
             this.btnBrowseD2Location.TabIndex = 17;
@@ -209,51 +263,85 @@
             this.btnBrowseD2Location.UseVisualStyleBackColor = true;
             this.btnBrowseD2Location.Click += new System.EventHandler(this.btnBrowseD2Location_Click);
             // 
-            // chkShowArea
-            // 
-            this.chkShowArea.AutoSize = true;
-            this.chkShowArea.Location = new System.Drawing.Point(125, 15);
-            this.chkShowArea.Name = "chkShowArea";
-            this.chkShowArea.Size = new System.Drawing.Size(122, 17);
-            this.chkShowArea.TabIndex = 16;
-            this.chkShowArea.Text = "Display Current Area";
-            this.chkShowArea.UseVisualStyleBackColor = true;
-            this.chkShowArea.CheckedChanged += new System.EventHandler(this.chkShowArea_CheckedChanged);
-            // 
-            // cboLanguage
-            // 
-            this.cboLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboLanguage.FormattingEnabled = true;
-            this.cboLanguage.Location = new System.Drawing.Point(76, 286);
-            this.cboLanguage.Name = "cboLanguage";
-            this.cboLanguage.Size = new System.Drawing.Size(132, 21);
-            this.cboLanguage.TabIndex = 14;
-            this.cboLanguage.SelectedIndexChanged += new System.EventHandler(this.cboLanguage_SelectedIndexChanged);
-            // 
             // label1
             // 
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F);
             this.label1.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.label1.Location = new System.Drawing.Point(111, 135);
+            this.label1.Location = new System.Drawing.Point(7, 46);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(133, 13);
             this.label1.TabIndex = 15;
             this.label1.Text = "Leave blank to auto-detect";
             // 
-            // label11
+            // grpGameInfo
             // 
-            this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(12, 289);
-            this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(58, 13);
-            this.label11.TabIndex = 13;
-            this.label11.Text = "Language:";
+            this.grpGameInfo.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.grpGameInfo.Controls.Add(this.chkGameInfoTextShadow);
+            this.grpGameInfo.Controls.Add(this.btnClearGameInfoFont);
+            this.grpGameInfo.Controls.Add(this.btnGameInfoFont);
+            this.grpGameInfo.Controls.Add(this.chkShowOverlayFPS);
+            this.grpGameInfo.Controls.Add(this.chkGameInfo);
+            this.grpGameInfo.Controls.Add(this.chkShowArea);
+            this.grpGameInfo.Controls.Add(this.txtHuntIP);
+            this.grpGameInfo.Controls.Add(this.label7);
+            this.grpGameInfo.Location = new System.Drawing.Point(5, 4);
+            this.grpGameInfo.Name = "grpGameInfo";
+            this.grpGameInfo.Size = new System.Drawing.Size(313, 103);
+            this.grpGameInfo.TabIndex = 23;
+            this.grpGameInfo.TabStop = false;
+            this.grpGameInfo.Text = "Game Info";
+            // 
+            // chkGameInfoTextShadow
+            // 
+            this.chkGameInfoTextShadow.AutoSize = true;
+            this.chkGameInfoTextShadow.Location = new System.Drawing.Point(170, 69);
+            this.chkGameInfoTextShadow.Name = "chkGameInfoTextShadow";
+            this.chkGameInfoTextShadow.Size = new System.Drawing.Size(89, 17);
+            this.chkGameInfoTextShadow.TabIndex = 34;
+            this.chkGameInfoTextShadow.Text = "Text Shadow";
+            this.chkGameInfoTextShadow.UseVisualStyleBackColor = true;
+            this.chkGameInfoTextShadow.CheckedChanged += new System.EventHandler(this.chkGameInfoTextShadow_CheckedChanged);
+            // 
+            // btnClearGameInfoFont
+            // 
+            this.btnClearGameInfoFont.FlatAppearance.BorderSize = 0;
+            this.btnClearGameInfoFont.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearGameInfoFont.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearGameInfoFont.Location = new System.Drawing.Point(85, 69);
+            this.btnClearGameInfoFont.Name = "btnClearGameInfoFont";
+            this.btnClearGameInfoFont.Size = new System.Drawing.Size(23, 23);
+            this.btnClearGameInfoFont.TabIndex = 33;
+            this.btnClearGameInfoFont.Text = "X";
+            this.btnClearGameInfoFont.UseVisualStyleBackColor = true;
+            this.btnClearGameInfoFont.Click += new System.EventHandler(this.btnClearGameInfoFont_Click);
+            // 
+            // btnGameInfoFont
+            // 
+            this.btnGameInfoFont.BackColor = System.Drawing.Color.Transparent;
+            this.btnGameInfoFont.Location = new System.Drawing.Point(10, 69);
+            this.btnGameInfoFont.Name = "btnGameInfoFont";
+            this.btnGameInfoFont.Size = new System.Drawing.Size(75, 23);
+            this.btnGameInfoFont.TabIndex = 32;
+            this.btnGameInfoFont.Text = "Font";
+            this.btnGameInfoFont.UseVisualStyleBackColor = false;
+            this.btnGameInfoFont.Click += new System.EventHandler(this.btnGameInfoFont_Click);
+            // 
+            // chkShowOverlayFPS
+            // 
+            this.chkShowOverlayFPS.AutoSize = true;
+            this.chkShowOverlayFPS.Location = new System.Drawing.Point(170, 44);
+            this.chkShowOverlayFPS.Name = "chkShowOverlayFPS";
+            this.chkShowOverlayFPS.Size = new System.Drawing.Size(115, 17);
+            this.chkShowOverlayFPS.TabIndex = 2;
+            this.chkShowOverlayFPS.Text = "Show Overlay FPS";
+            this.chkShowOverlayFPS.UseVisualStyleBackColor = true;
+            this.chkShowOverlayFPS.CheckedChanged += new System.EventHandler(this.chkShowOverlayFPS_CheckedChanged);
             // 
             // chkGameInfo
             // 
             this.chkGameInfo.AutoSize = true;
-            this.chkGameInfo.Location = new System.Drawing.Point(15, 15);
+            this.chkGameInfo.Location = new System.Drawing.Point(10, 19);
             this.chkGameInfo.Name = "chkGameInfo";
             this.chkGameInfo.Size = new System.Drawing.Size(104, 17);
             this.chkGameInfo.TabIndex = 6;
@@ -261,40 +349,33 @@
             this.chkGameInfo.UseVisualStyleBackColor = true;
             this.chkGameInfo.CheckedChanged += new System.EventHandler(this.chkGameInfo_CheckedChanged);
             // 
+            // chkShowArea
+            // 
+            this.chkShowArea.AutoSize = true;
+            this.chkShowArea.Location = new System.Drawing.Point(170, 19);
+            this.chkShowArea.Name = "chkShowArea";
+            this.chkShowArea.Size = new System.Drawing.Size(122, 17);
+            this.chkShowArea.TabIndex = 16;
+            this.chkShowArea.Text = "Display Current Area";
+            this.chkShowArea.UseVisualStyleBackColor = true;
+            this.chkShowArea.CheckedChanged += new System.EventHandler(this.chkShowArea_CheckedChanged);
+            // 
             // txtHuntIP
             // 
-            this.txtHuntIP.Location = new System.Drawing.Point(114, 167);
+            this.txtHuntIP.Location = new System.Drawing.Point(56, 42);
             this.txtHuntIP.Name = "txtHuntIP";
-            this.txtHuntIP.Size = new System.Drawing.Size(116, 20);
+            this.txtHuntIP.Size = new System.Drawing.Size(87, 20);
             this.txtHuntIP.TabIndex = 9;
             this.txtHuntIP.TextChanged += new System.EventHandler(this.txtHuntIP_TextChanged);
             // 
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(12, 170);
+            this.label7.Location = new System.Drawing.Point(7, 45);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(89, 13);
+            this.label7.Size = new System.Drawing.Size(43, 13);
             this.label7.TabIndex = 10;
-            this.label7.Text = "Hunt for Game IP";
-            // 
-            // txtD2Path
-            // 
-            this.txtD2Path.Enabled = false;
-            this.txtD2Path.Location = new System.Drawing.Point(114, 112);
-            this.txtD2Path.Name = "txtD2Path";
-            this.txtD2Path.Size = new System.Drawing.Size(116, 20);
-            this.txtD2Path.TabIndex = 7;
-            this.txtD2Path.TextChanged += new System.EventHandler(this.txtD2Path_TextChanged);
-            // 
-            // label6
-            // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(12, 115);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(96, 13);
-            this.label6.TabIndex = 8;
-            this.label6.Text = "D2LoD 1.13c Path";
+            this.label7.Text = "Hunt IP";
             // 
             // tabPage1
             // 
@@ -856,9 +937,9 @@
             // 
             // tabLabel
             // 
+            this.tabLabel.Controls.Add(this.chkTextShadow);
             this.tabLabel.Controls.Add(this.btnClearLabelFont);
             this.tabLabel.Controls.Add(this.btnClearLabelColor);
-            this.tabLabel.Controls.Add(this.label3);
             this.tabLabel.Controls.Add(this.btnFont);
             this.tabLabel.Controls.Add(this.btnLabelColor);
             this.tabLabel.Location = new System.Drawing.Point(4, 22);
@@ -868,6 +949,18 @@
             this.tabLabel.TabIndex = 1;
             this.tabLabel.Text = "Label";
             this.tabLabel.UseVisualStyleBackColor = true;
+            // 
+            // chkTextShadow
+            // 
+            this.chkTextShadow.AutoSize = true;
+            this.chkTextShadow.Location = new System.Drawing.Point(142, 65);
+            this.chkTextShadow.Name = "chkTextShadow";
+            this.chkTextShadow.Size = new System.Drawing.Size(89, 17);
+            this.chkTextShadow.TabIndex = 32;
+            this.chkTextShadow.Text = "Text Shadow";
+            this.chkTextShadow.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.chkTextShadow.UseVisualStyleBackColor = true;
+            this.chkTextShadow.CheckedChanged += new System.EventHandler(this.chkTextShadow_CheckedChanged);
             // 
             // btnClearLabelFont
             // 
@@ -894,16 +987,6 @@
             this.btnClearLabelColor.Text = "X";
             this.btnClearLabelColor.UseVisualStyleBackColor = true;
             this.btnClearLabelColor.Click += new System.EventHandler(this.btnClearLabelColor_Click);
-            // 
-            // label3
-            // 
-            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F);
-            this.label3.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.label3.Location = new System.Drawing.Point(8, 87);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(250, 19);
-            this.label3.TabIndex = 24;
-            this.label3.Text = "(font styles - bold, italic, etc... not yet implemented)";
             // 
             // btnFont
             // 
@@ -1061,12 +1144,12 @@
             // 
             // tabPage6
             // 
+            this.tabPage6.Controls.Add(this.chkLogTextShadow);
             this.tabPage6.Controls.Add(this.btnClearLogFont);
             this.tabPage6.Controls.Add(this.lblSoundVolumeValue);
             this.tabPage6.Controls.Add(this.soundVolume);
             this.tabPage6.Controls.Add(this.label10);
             this.tabPage6.Controls.Add(this.lblItemDisplayForSecondsValue);
-            this.tabPage6.Controls.Add(this.label19);
             this.tabPage6.Controls.Add(this.itemDisplayForSeconds);
             this.tabPage6.Controls.Add(this.btnLogFont);
             this.tabPage6.Controls.Add(this.label21);
@@ -1084,6 +1167,17 @@
             this.tabPage6.TabIndex = 5;
             this.tabPage6.Text = "Item Log";
             this.tabPage6.UseVisualStyleBackColor = true;
+            // 
+            // chkLogTextShadow
+            // 
+            this.chkLogTextShadow.AutoSize = true;
+            this.chkLogTextShadow.Location = new System.Drawing.Point(142, 273);
+            this.chkLogTextShadow.Name = "chkLogTextShadow";
+            this.chkLogTextShadow.Size = new System.Drawing.Size(89, 17);
+            this.chkLogTextShadow.TabIndex = 31;
+            this.chkLogTextShadow.Text = "Text Shadow";
+            this.chkLogTextShadow.UseVisualStyleBackColor = true;
+            this.chkLogTextShadow.CheckedChanged += new System.EventHandler(this.chkLogTextShadow_CheckedChanged);
             // 
             // btnClearLogFont
             // 
@@ -1143,16 +1237,6 @@
             this.lblItemDisplayForSecondsValue.TabIndex = 25;
             this.lblItemDisplayForSecondsValue.Text = "100 s";
             this.lblItemDisplayForSecondsValue.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // label19
-            // 
-            this.label19.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F);
-            this.label19.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.label19.Location = new System.Drawing.Point(11, 296);
-            this.label19.Name = "label19";
-            this.label19.Size = new System.Drawing.Size(250, 19);
-            this.label19.TabIndex = 23;
-            this.label19.Text = "(font styles - bold, italic, etc... not yet implemented)";
             // 
             // itemDisplayForSeconds
             // 
@@ -1362,7 +1446,6 @@
             // tabPage4
             // 
             this.tabPage4.Controls.Add(this.groupBox2);
-            this.tabPage4.Controls.Add(this.chkShowOverlayFPS);
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Size = new System.Drawing.Size(324, 325);
@@ -1375,9 +1458,9 @@
             this.groupBox2.Controls.Add(this.btnRemoveHidden);
             this.groupBox2.Controls.Add(this.btnAddHidden);
             this.groupBox2.Controls.Add(this.lstHidden);
-            this.groupBox2.Location = new System.Drawing.Point(14, 48);
+            this.groupBox2.Location = new System.Drawing.Point(5, 4);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(300, 245);
+            this.groupBox2.Size = new System.Drawing.Size(300, 189);
             this.groupBox2.TabIndex = 2;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Hidden Areas";
@@ -1407,19 +1490,8 @@
             this.lstHidden.FormattingEnabled = true;
             this.lstHidden.Location = new System.Drawing.Point(10, 19);
             this.lstHidden.Name = "lstHidden";
-            this.lstHidden.Size = new System.Drawing.Size(253, 212);
+            this.lstHidden.Size = new System.Drawing.Size(253, 160);
             this.lstHidden.TabIndex = 0;
-            // 
-            // chkShowOverlayFPS
-            // 
-            this.chkShowOverlayFPS.AutoSize = true;
-            this.chkShowOverlayFPS.Location = new System.Drawing.Point(14, 13);
-            this.chkShowOverlayFPS.Name = "chkShowOverlayFPS";
-            this.chkShowOverlayFPS.Size = new System.Drawing.Size(115, 17);
-            this.chkShowOverlayFPS.TabIndex = 1;
-            this.chkShowOverlayFPS.Text = "Show Overlay FPS";
-            this.chkShowOverlayFPS.UseVisualStyleBackColor = true;
-            this.chkShowOverlayFPS.CheckedChanged += new System.EventHandler(this.chkShowOverlayFPS_CheckedChanged);
             // 
             // ConfigEditor
             // 
@@ -1436,7 +1508,12 @@
             this.Text = "Configuration - MapAssist";
             this.tabControl1.ResumeLayout(false);
             this.tabPage5.ResumeLayout(false);
-            this.tabPage5.PerformLayout();
+            this.groupBox5.ResumeLayout(false);
+            this.groupBox5.PerformLayout();
+            this.groupBox4.ResumeLayout(false);
+            this.groupBox4.PerformLayout();
+            this.grpGameInfo.ResumeLayout(false);
+            this.grpGameInfo.PerformLayout();
             this.tabPage1.ResumeLayout(false);
             this.panel1.ResumeLayout(false);
             this.groupBox3.ResumeLayout(false);
@@ -1456,6 +1533,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.iconThickness)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.iconSize)).EndInit();
             this.tabLabel.ResumeLayout(false);
+            this.tabLabel.PerformLayout();
             this.tabLine.ResumeLayout(false);
             this.tabLine.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.lineThicknessSize)).EndInit();
@@ -1467,7 +1545,6 @@
             this.tabPage3.ResumeLayout(false);
             this.tabPage3.PerformLayout();
             this.tabPage4.ResumeLayout(false);
-            this.tabPage4.PerformLayout();
             this.groupBox2.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -1496,11 +1573,9 @@
         private System.Windows.Forms.TrackBar mapZoom;
         private System.Windows.Forms.TabPage tabPage5;
         private System.Windows.Forms.CheckBox chkGameInfo;
-        private System.Windows.Forms.Label label6;
         private System.Windows.Forms.TextBox txtD2Path;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.TextBox txtHuntIP;
-        private System.Windows.Forms.CheckBox chkShowOverlayFPS;
         private System.Windows.Forms.Label label8;
         private System.Windows.Forms.ComboBox cboRenderOption;
         private System.Windows.Forms.TabControl tabDrawing;
@@ -1521,8 +1596,6 @@
         private System.Windows.Forms.Label lblLineArrow;
         private System.Windows.Forms.TrackBar lineArrowSize;
         private System.Windows.Forms.Button btnLineColor;
-        private System.Windows.Forms.ComboBox cboLanguage;
-        private System.Windows.Forms.Label label11;
         private System.Windows.Forms.Label label13;
         private System.Windows.Forms.Label label12;
         private System.Windows.Forms.TextBox txtZoomOutKey;
@@ -1532,7 +1605,6 @@
         private System.Windows.Forms.Label label15;
         private System.Windows.Forms.Label label14;
         private System.Windows.Forms.TabPage tabPage6;
-        private System.Windows.Forms.Label label19;
         private System.Windows.Forms.Button btnLogFont;
         private System.Windows.Forms.Label label18;
         private System.Windows.Forms.TextBox txtSoundFile;
@@ -1554,18 +1626,11 @@
         private System.Windows.Forms.Button btnIconOutlineColor;
         private System.Windows.Forms.Label lblIconThicknessValue;
         private System.Windows.Forms.Label lblIconSizeValue;
-        private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Label lblLineThicknessSizeValue;
         private System.Windows.Forms.Label lblLineArrowSizeValue;
         private System.Windows.Forms.CheckBox chkShowArea;
         private System.Windows.Forms.Button btnWalkableColor;
         private System.Windows.Forms.Button btnBorderColor;
-        private System.Windows.Forms.GroupBox groupBox3;
-        private System.Windows.Forms.Label lblBuffSizeValue;
-        private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.Label lblBuffSize;
-        private System.Windows.Forms.ComboBox cboBuffPosition;
-        private System.Windows.Forms.TrackBar buffSize;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.Button btnRemoveHidden;
         private System.Windows.Forms.Button btnAddHidden;
@@ -1584,5 +1649,22 @@
         private System.Windows.Forms.Button btnClearLogFont;
         private System.Windows.Forms.Button btnClearBorderColor;
         private System.Windows.Forms.Button btnClearWalkableColor;
+        private System.Windows.Forms.GroupBox groupBox4;
+        private System.Windows.Forms.GroupBox grpGameInfo;
+        private System.Windows.Forms.CheckBox chkShowOverlayFPS;
+        private System.Windows.Forms.CheckBox chkTextShadow;
+        private System.Windows.Forms.CheckBox chkLogTextShadow;
+        private System.Windows.Forms.CheckBox chkGameInfoTextShadow;
+        private System.Windows.Forms.Button btnClearGameInfoFont;
+        private System.Windows.Forms.Button btnGameInfoFont;
+        private System.Windows.Forms.GroupBox groupBox5;
+        private System.Windows.Forms.ComboBox cboLanguage;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.GroupBox groupBox3;
+        private System.Windows.Forms.Label lblBuffSizeValue;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label lblBuffSize;
+        private System.Windows.Forms.ComboBox cboBuffPosition;
+        private System.Windows.Forms.TrackBar buffSize;
     }
 }

--- a/ConfigEditor.cs
+++ b/ConfigEditor.cs
@@ -734,10 +734,5 @@ namespace MapAssist
 
             return brightness > 128 ? Color.Black : Color.White;
         }
-
-        private void IgnoreMouseWheel(object sender, MouseEventArgs e)
-        {
-
-        }
     }
 }

--- a/ConfigEditor.cs
+++ b/ConfigEditor.cs
@@ -73,7 +73,7 @@ namespace MapAssist
             txtHuntIP.ReadOnly = !MapAssistConfiguration.Loaded.GameInfo.ShowGameIP;
             txtHuntIP.Text = MapAssistConfiguration.Loaded.GameInfo.HuntingIP;
             txtD2Path.Text = MapAssistConfiguration.Loaded.D2Path;
-            chkGameInfoTextShadow.Checked = MapAssistConfiguration.Loaded.GameInfo.LabelFontShadow;
+            chkGameInfoTextShadow.Checked = MapAssistConfiguration.Loaded.GameInfo.LabelTextShadow;
             btnClearGameInfoFont.Visible = MapAssistConfiguration.Loaded.GameInfo.LabelFont != MapAssistConfiguration.Default.GameInfo.LabelFont ||
                 MapAssistConfiguration.Loaded.GameInfo.LabelFontSize != MapAssistConfiguration.Default.GameInfo.LabelFontSize;
             chkShowOverlayFPS.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowOverlayFPS;
@@ -93,7 +93,7 @@ namespace MapAssist
             lblItemDisplayForSecondsValue.Text = $"{itemDisplayForSeconds.Value * 5} s";
             btnClearLogFont.Visible = MapAssistConfiguration.Loaded.ItemLog.LabelFont != MapAssistConfiguration.Default.ItemLog.LabelFont ||
                 MapAssistConfiguration.Loaded.ItemLog.LabelFontSize != MapAssistConfiguration.Default.ItemLog.LabelFontSize;
-            chkLogTextShadow.Checked = MapAssistConfiguration.Loaded.ItemLog.LabelFontShadow;
+            chkLogTextShadow.Checked = MapAssistConfiguration.Loaded.ItemLog.LabelTextShadow;
 
             if (MapAssistConfiguration.Loaded.MapColorConfiguration.Walkable != null)
             {
@@ -296,7 +296,7 @@ namespace MapAssist
 
         private void chkGameInfoTextShadow_CheckedChanged(object sender, EventArgs e)
         {
-            MapAssistConfiguration.Loaded.GameInfo.LabelFontShadow = chkGameInfoTextShadow.Checked;
+            MapAssistConfiguration.Loaded.GameInfo.LabelTextShadow = chkGameInfoTextShadow.Checked;
         }
 
         private void cboRenderOption_SelectedIndexChanged(object sender, EventArgs e)
@@ -340,7 +340,7 @@ namespace MapAssist
 
                 dynamic defaultlabelProp = MapAssistConfiguration.Default.MapConfiguration.GetType().GetProperty(cboRenderOption.Text.ToPascalCase()).GetValue(MapAssistConfiguration.Default.MapConfiguration, null);
                 btnClearLabelFont.Visible = iconProp.LabelFont != defaultlabelProp.LabelFont || iconProp.LabelFontSize != defaultlabelProp.LabelFontSize;
-                chkTextShadow.Checked = iconProp.LabelFontShadow;
+                chkTextShadow.Checked = iconProp.LabelTextShadow;
 
                 btnLineColor.BackColor = iconProp.LineColor;
                 btnLineColor.ForeColor = ContrastTextColor(btnLineColor.BackColor);
@@ -530,8 +530,8 @@ namespace MapAssist
 
         private void chkTextShadow_CheckedChanged(object sender, EventArgs e)
         {
-            var labelFontShadow = SelectedProperty.PropertyType.GetProperty("LabelFontShadow");
-            labelFontShadow.SetValue(SelectedProperty.GetValue(MapAssistConfiguration.Loaded.MapConfiguration, null), chkTextShadow.Checked, null);
+            var LabelTextShadow = SelectedProperty.PropertyType.GetProperty("LabelTextShadow");
+            LabelTextShadow.SetValue(SelectedProperty.GetValue(MapAssistConfiguration.Loaded.MapConfiguration, null), chkTextShadow.Checked, null);
         }
 
         private void cboLanguage_SelectedIndexChanged(object sender, EventArgs e)
@@ -608,7 +608,7 @@ namespace MapAssist
 
         private void chkLogTextShadow_CheckedChanged(object sender, EventArgs e)
         {
-            MapAssistConfiguration.Loaded.ItemLog.LabelFontShadow = chkLogTextShadow.Checked;
+            MapAssistConfiguration.Loaded.ItemLog.LabelTextShadow = chkLogTextShadow.Checked;
         }
 
         private void txtToggleMapKey_TextChanged(object sender, EventArgs e)

--- a/ConfigEditor.cs
+++ b/ConfigEditor.cs
@@ -70,9 +70,12 @@ namespace MapAssist
 
             chkGameInfo.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowGameIP;
             chkShowArea.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowAreaLevel;
+            txtHuntIP.ReadOnly = !MapAssistConfiguration.Loaded.GameInfo.ShowGameIP;
             txtHuntIP.Text = MapAssistConfiguration.Loaded.GameInfo.HuntingIP;
             txtD2Path.Text = MapAssistConfiguration.Loaded.D2Path;
-
+            chkGameInfoTextShadow.Checked = MapAssistConfiguration.Loaded.GameInfo.LabelFontShadow;
+            btnClearGameInfoFont.Visible = MapAssistConfiguration.Loaded.GameInfo.LabelFont != MapAssistConfiguration.Default.GameInfo.LabelFont ||
+                MapAssistConfiguration.Loaded.GameInfo.LabelFontSize != MapAssistConfiguration.Default.GameInfo.LabelFontSize;
             chkShowOverlayFPS.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowOverlayFPS;
 
             new Hotkey(MapAssistConfiguration.Loaded.HotkeyConfiguration.ToggleKey.ToString()).Monitor(txtToggleMapKey);
@@ -90,6 +93,7 @@ namespace MapAssist
             lblItemDisplayForSecondsValue.Text = $"{itemDisplayForSeconds.Value * 5} s";
             btnClearLogFont.Visible = MapAssistConfiguration.Loaded.ItemLog.LabelFont != MapAssistConfiguration.Default.ItemLog.LabelFont ||
                 MapAssistConfiguration.Loaded.ItemLog.LabelFontSize != MapAssistConfiguration.Default.ItemLog.LabelFontSize;
+            chkLogTextShadow.Checked = MapAssistConfiguration.Loaded.ItemLog.LabelFontShadow;
 
             if (MapAssistConfiguration.Loaded.MapColorConfiguration.Walkable != null)
             {
@@ -234,6 +238,7 @@ namespace MapAssist
         private void chkGameInfo_CheckedChanged(object sender, EventArgs e)
         {
             MapAssistConfiguration.Loaded.GameInfo.ShowGameIP = chkGameInfo.Checked;
+            txtHuntIP.ReadOnly = !MapAssistConfiguration.Loaded.GameInfo.ShowGameIP;
         }
 
         private void chkShowArea_CheckedChanged(object sender, EventArgs e)
@@ -254,6 +259,44 @@ namespace MapAssist
         private void chkShowOverlayFPS_CheckedChanged(object sender, EventArgs e)
         {
             MapAssistConfiguration.Loaded.GameInfo.ShowOverlayFPS = chkShowOverlayFPS.Checked;
+        }
+
+        private void btnGameInfoFont_Click(object sender, EventArgs e)
+        {
+            var labelFont = MapAssistConfiguration.Loaded.GameInfo.LabelFont;
+            var labelSize = (float)MapAssistConfiguration.Loaded.GameInfo.LabelFontSize;
+            if (labelFont == null)
+            {
+                labelFont = "Helvetica";
+                labelSize = 16;
+            }
+            var fontDlg = new FontDialog();
+            fontDlg.Font = new Font(labelFont, labelSize, FontStyle.Regular);
+            fontDlg.ShowEffects = false;
+            if (fontDlg.ShowDialog() == DialogResult.OK)
+            {
+                MapAssistConfiguration.Loaded.GameInfo.LabelFont = fontDlg.Font.Name;
+                MapAssistConfiguration.Loaded.GameInfo.LabelFontSize = fontDlg.Font.Size;
+
+                btnClearGameInfoFont.Visible = true;
+                fontDlg.Dispose();
+            } else
+            {
+                fontDlg.Dispose();
+            }
+        }
+
+        private void btnClearGameInfoFont_Click(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.GameInfo.LabelFont = MapAssistConfiguration.Default.GameInfo.LabelFont;
+            MapAssistConfiguration.Loaded.GameInfo.LabelFontSize = MapAssistConfiguration.Default.GameInfo.LabelFontSize;
+
+            btnClearGameInfoFont.Visible = false;
+        }
+
+        private void chkGameInfoTextShadow_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.GameInfo.LabelFontShadow = chkGameInfoTextShadow.Checked;
         }
 
         private void cboRenderOption_SelectedIndexChanged(object sender, EventArgs e)
@@ -297,6 +340,7 @@ namespace MapAssist
 
                 dynamic defaultlabelProp = MapAssistConfiguration.Default.MapConfiguration.GetType().GetProperty(cboRenderOption.Text.ToPascalCase()).GetValue(MapAssistConfiguration.Default.MapConfiguration, null);
                 btnClearLabelFont.Visible = iconProp.LabelFont != defaultlabelProp.LabelFont || iconProp.LabelFontSize != defaultlabelProp.LabelFontSize;
+                chkTextShadow.Checked = iconProp.LabelFontShadow;
 
                 btnLineColor.BackColor = iconProp.LineColor;
                 btnLineColor.ForeColor = ContrastTextColor(btnLineColor.BackColor);
@@ -421,6 +465,7 @@ namespace MapAssist
             }
             var fontDlg = new FontDialog();
             fontDlg.Font = new Font(labelFont, labelSize, FontStyle.Regular);
+            fontDlg.ShowEffects = false;
             if (fontDlg.ShowDialog() == DialogResult.OK)
             {
                 var labelPropFont = SelectedProperty.PropertyType.GetProperty("LabelFont");
@@ -483,6 +528,12 @@ namespace MapAssist
             lblLineThicknessSizeValue.Text = lineThicknessSize.Value.ToString();
         }
 
+        private void chkTextShadow_CheckedChanged(object sender, EventArgs e)
+        {
+            var labelFontShadow = SelectedProperty.PropertyType.GetProperty("LabelFontShadow");
+            labelFontShadow.SetValue(SelectedProperty.GetValue(MapAssistConfiguration.Loaded.MapConfiguration, null), chkTextShadow.Checked, null);
+        }
+
         private void cboLanguage_SelectedIndexChanged(object sender, EventArgs e)
         {
             MapAssistConfiguration.Loaded.LanguageCode = (Locale)cboLanguage.SelectedIndex;
@@ -537,6 +588,7 @@ namespace MapAssist
             }
             var fontDlg = new FontDialog();
             fontDlg.Font = new Font(labelFont, labelSize, FontStyle.Regular);
+            fontDlg.ShowEffects = false;
             if (fontDlg.ShowDialog() == DialogResult.OK)
             {
                 MapAssistConfiguration.Loaded.ItemLog.LabelFont = fontDlg.Font.Name;
@@ -552,6 +604,11 @@ namespace MapAssist
             MapAssistConfiguration.Loaded.ItemLog.LabelFontSize = MapAssistConfiguration.Default.ItemLog.LabelFontSize;
 
             btnClearLogFont.Visible = false;
+        }
+
+        private void chkLogTextShadow_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.ItemLog.LabelFontShadow = chkLogTextShadow.Checked;
         }
 
         private void txtToggleMapKey_TextChanged(object sender, EventArgs e)
@@ -676,6 +733,11 @@ namespace MapAssist
                 backgroundColor.B * backgroundColor.B * .114);
 
             return brightness > 128 ? Color.Black : Color.White;
+        }
+
+        private void IgnoreMouseWheel(object sender, MouseEventArgs e)
+        {
+
         }
     }
 }

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -786,8 +786,9 @@ namespace MapAssist.Helpers
 
             // Setup
             var font = MapAssistConfiguration.Loaded.GameInfo.LabelFont;
-            var fontSize = MapAssistConfiguration.Loaded.GameInfo.LabelFontSize;
+            var fontSize = (float)MapAssistConfiguration.Loaded.GameInfo.LabelFontSize;
             var fontHeight = (fontSize + fontSize / 2f);
+            var fontShadow = MapAssistConfiguration.Loaded.GameInfo.LabelFontShadow;
 
             // Game IP
             if (MapAssistConfiguration.Loaded.GameInfo.ShowGameIP)
@@ -795,7 +796,7 @@ namespace MapAssist.Helpers
                 var fontColor = _gameData.Session.GameIP == MapAssistConfiguration.Loaded.GameInfo.HuntingIP ? Color.Green : Color.Red;
 
                 var ipText = "Game IP: " + _gameData.Session.GameIP;
-                DrawText(gfx, anchor, ipText, font, fontSize, fontColor);
+                DrawText(gfx, anchor, ipText, font, fontSize, fontColor, fontShadow);
 
                 anchor.Y += fontHeight + 5;
             }
@@ -805,7 +806,7 @@ namespace MapAssist.Helpers
             {
                 // Area Label
                 var areaText = "Area: " + Utils.GetAreaLabel(_areaData.Area, _gameData.Difficulty, true);
-                DrawText(gfx, anchor, areaText, font, fontSize, Color.FromArgb(255, 218, 100));
+                DrawText(gfx, anchor, areaText, font, fontSize, Color.FromArgb(255, 218, 100), fontShadow);
 
                 anchor.Y += fontHeight + 5;
             }
@@ -814,14 +815,14 @@ namespace MapAssist.Helpers
             if (MapAssistConfiguration.Loaded.GameInfo.ShowOverlayFPS)
             {
                 var fpsText = "FPS: " + gfx.FPS.ToString() + "   " + "DeltaTime: " + e.DeltaTime.ToString();
-                DrawText(gfx, anchor, fpsText, font, fontSize, Color.FromArgb(0, 255, 0));
+                DrawText(gfx, anchor, fpsText, font, fontSize, Color.FromArgb(0, 255, 0), fontShadow);
 
                 anchor.Y += fontHeight + 5;
             }
 
             if (errorLoadingAreaData)
             {
-                DrawText(gfx, anchor, "ERROR LOADING GAME MAP!", font, (int)Math.Round(fontSize * 1.5), Color.Orange);
+                DrawText(gfx, anchor, "ERROR LOADING GAME MAP!", font, (int)Math.Round(fontSize * 1.5), Color.Orange, fontShadow);
                 anchor.Y += (int)Math.Round(fontHeight * 1.5) + 5;
             }
 
@@ -838,6 +839,9 @@ namespace MapAssist.Helpers
             // Setup
             var fontSize = (float)MapAssistConfiguration.Loaded.ItemLog.LabelFontSize;
             var fontHeight = (fontSize + fontSize / 2f);
+            var fontShadow = MapAssistConfiguration.Loaded.ItemLog.LabelFontShadow;
+            var shadowBrush = CreateSolidBrush(gfx, Color.Black, 0.6f);
+            var shadowOffset = fontSize * 0.0625f; // 1/16th
 
             // Item Log
             var ItemLog = Items.CurrentItemLog.ToArray();
@@ -892,9 +896,16 @@ namespace MapAssist.Helpers
                         break;
                 }
 
+                var position = anchor.Add(0, i * fontHeight);
                 var brush = CreateSolidBrush(gfx, fontColor, 1);
+                var text = itemLabelExtra + itemSpecialName + itemBaseName;
 
-                gfx.DrawText(font, brush, anchor.Add(0, i * fontHeight), itemLabelExtra + itemSpecialName + itemBaseName);
+                if (fontShadow)
+                {
+                    gfx.DrawText(font, shadowBrush, position.X + shadowOffset, position.Y + shadowOffset, text);
+                }
+
+                gfx.DrawText(font, brush, position, text);
             }
         }
 
@@ -1037,6 +1048,7 @@ namespace MapAssist.Helpers
             var font = CreateFont(gfx, rendering.LabelFont, rendering.LabelFontSize);
             var iconShape = GetIconShape(rendering).ToRectangle();
             var textSize = gfx.MeasureString(font, text);
+            var textShadow = rendering.LabelFontShadow;
 
             var multiplier = playerCoord.Y < position.Y ? 1 : -1;
             if (rendering.CanDrawIcon())
@@ -1047,13 +1059,13 @@ namespace MapAssist.Helpers
             position = position.Add(new Point(0, (textSize.Y / 2 + 5) * (!rendering.CanDrawArrowHead() ? -1 : multiplier)));
             position = MoveTextInBounds(position, text, textSize);
 
-            DrawText(gfx, position, text, rendering.LabelFont, rendering.LabelFontSize, useColor,
+            DrawText(gfx, position, text, rendering.LabelFont, rendering.LabelFontSize, useColor, textShadow,
                 centerText: true);
 
             renderTarget.Transform = currentTransform;
         }
 
-        private void DrawText(Graphics gfx, Point position, string text, string fontFamily, float fontSize, Color color,
+        private void DrawText(Graphics gfx, Point position, string text, string fontFamily, float fontSize, Color color, bool textShadow,
             bool centerText = false)
         {
             var font = CreateFont(gfx, fontFamily, fontSize);
@@ -1063,6 +1075,13 @@ namespace MapAssist.Helpers
             {
                 var stringSize = gfx.MeasureString(font, text);
                 position = position.Subtract(stringSize.X / 2, stringSize.Y / 2);
+            }
+
+            if (textShadow)
+            {
+                var shadowBrush = CreateSolidBrush(gfx, Color.Black, 0.6f);
+                var shadowOffset = fontSize * 0.0625f;
+                gfx.DrawText(font, shadowBrush, position.X + shadowOffset, position.Y + shadowOffset, text);
             }
 
             gfx.DrawText(font, brush, position, text);

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -215,7 +215,7 @@ namespace MapAssist.Helpers
 
                 if (poi.RenderingSettings.CanDrawLine())
                 {
-                    var padding = poi.RenderingSettings.CanDrawLabel() ? poi.RenderingSettings.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
+                    var padding = poi.RenderingSettings.CanDrawLabel() ? (float)poi.RenderingSettings.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
                     var poiPosition = MovePointInBounds(poi.Position, _gameData.PlayerPosition, padding);
                     DrawLine(gfx, poi.RenderingSettings, _gameData.PlayerPosition, poiPosition);
                 }
@@ -532,7 +532,7 @@ namespace MapAssist.Helpers
                     }
                     if (canDrawLine && corpse.Name == _gameData.PlayerUnit.Name)
                     {
-                        var padding = canDrawLabel ? rendering.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
+                        var padding = canDrawLabel ? (float)rendering.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
                         var poiPosition = MovePointInBounds(corpse.Position, _gameData.PlayerPosition, padding);
                         DrawLine(gfx, rendering, _gameData.PlayerPosition, poiPosition);
                     }
@@ -603,7 +603,7 @@ namespace MapAssist.Helpers
 
                             if (rendering.CanDrawLine() && playerUnit.HostileToPlayer)
                             {
-                                var padding = rendering.CanDrawLabel() ? MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
+                                var padding = rendering.CanDrawLabel() ? (float)MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.LabelFontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
                                 var poiPosition = MovePointInBounds(playerUnit.Position, _gameData.PlayerPosition, padding);
                                 DrawLine(gfx, MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer, _gameData.PlayerPosition, poiPosition);
                             }
@@ -788,7 +788,7 @@ namespace MapAssist.Helpers
             var font = MapAssistConfiguration.Loaded.GameInfo.LabelFont;
             var fontSize = (float)MapAssistConfiguration.Loaded.GameInfo.LabelFontSize;
             var fontHeight = (fontSize + fontSize / 2f);
-            var fontShadow = MapAssistConfiguration.Loaded.GameInfo.LabelFontShadow;
+            var textShadow = MapAssistConfiguration.Loaded.GameInfo.LabelTextShadow;
 
             // Game IP
             if (MapAssistConfiguration.Loaded.GameInfo.ShowGameIP)
@@ -796,7 +796,7 @@ namespace MapAssist.Helpers
                 var fontColor = _gameData.Session.GameIP == MapAssistConfiguration.Loaded.GameInfo.HuntingIP ? Color.Green : Color.Red;
 
                 var ipText = "Game IP: " + _gameData.Session.GameIP;
-                DrawText(gfx, anchor, ipText, font, fontSize, fontColor, fontShadow);
+                DrawText(gfx, anchor, ipText, font, fontSize, fontColor, textShadow);
 
                 anchor.Y += fontHeight + 5;
             }
@@ -806,7 +806,7 @@ namespace MapAssist.Helpers
             {
                 // Area Label
                 var areaText = "Area: " + Utils.GetAreaLabel(_areaData.Area, _gameData.Difficulty, true);
-                DrawText(gfx, anchor, areaText, font, fontSize, Color.FromArgb(255, 218, 100), fontShadow);
+                DrawText(gfx, anchor, areaText, font, fontSize, Color.FromArgb(255, 218, 100), textShadow);
 
                 anchor.Y += fontHeight + 5;
             }
@@ -815,14 +815,14 @@ namespace MapAssist.Helpers
             if (MapAssistConfiguration.Loaded.GameInfo.ShowOverlayFPS)
             {
                 var fpsText = "FPS: " + gfx.FPS.ToString() + "   " + "DeltaTime: " + e.DeltaTime.ToString();
-                DrawText(gfx, anchor, fpsText, font, fontSize, Color.FromArgb(0, 255, 0), fontShadow);
+                DrawText(gfx, anchor, fpsText, font, fontSize, Color.FromArgb(0, 255, 0), textShadow);
 
                 anchor.Y += fontHeight + 5;
             }
 
             if (errorLoadingAreaData)
             {
-                DrawText(gfx, anchor, "ERROR LOADING GAME MAP!", font, (int)Math.Round(fontSize * 1.5), Color.Orange, fontShadow);
+                DrawText(gfx, anchor, "ERROR LOADING GAME MAP!", font, (int)Math.Round(fontSize * 1.5), Color.Orange, textShadow);
                 anchor.Y += (int)Math.Round(fontHeight * 1.5) + 5;
             }
 
@@ -839,7 +839,7 @@ namespace MapAssist.Helpers
             // Setup
             var fontSize = (float)MapAssistConfiguration.Loaded.ItemLog.LabelFontSize;
             var fontHeight = (fontSize + fontSize / 2f);
-            var fontShadow = MapAssistConfiguration.Loaded.ItemLog.LabelFontShadow;
+            var textShadow = MapAssistConfiguration.Loaded.ItemLog.LabelTextShadow;
             var shadowBrush = CreateSolidBrush(gfx, Color.Black, 0.6f);
             var shadowOffset = fontSize * 0.0625f; // 1/16th
 
@@ -900,7 +900,7 @@ namespace MapAssist.Helpers
                 var brush = CreateSolidBrush(gfx, fontColor, 1);
                 var text = itemLabelExtra + itemSpecialName + itemBaseName;
 
-                if (fontShadow)
+                if (textShadow)
                 {
                     gfx.DrawText(font, shadowBrush, position.X + shadowOffset, position.Y + shadowOffset, text);
                 }
@@ -1045,10 +1045,10 @@ namespace MapAssist.Helpers
 
             var useColor = color ?? rendering.LabelColor;
 
-            var font = CreateFont(gfx, rendering.LabelFont, rendering.LabelFontSize);
+            var font = CreateFont(gfx, rendering.LabelFont, (float)rendering.LabelFontSize);
             var iconShape = GetIconShape(rendering).ToRectangle();
             var textSize = gfx.MeasureString(font, text);
-            var textShadow = rendering.LabelFontShadow;
+            var textShadow = rendering.LabelTextShadow;
 
             var multiplier = playerCoord.Y < position.Y ? 1 : -1;
             if (rendering.CanDrawIcon())
@@ -1059,7 +1059,7 @@ namespace MapAssist.Helpers
             position = position.Add(new Point(0, (textSize.Y / 2 + 5) * (!rendering.CanDrawArrowHead() ? -1 : multiplier)));
             position = MoveTextInBounds(position, text, textSize);
 
-            DrawText(gfx, position, text, rendering.LabelFont, rendering.LabelFontSize, useColor, textShadow,
+            DrawText(gfx, position, text, rendering.LabelFont, (float)rendering.LabelFontSize, useColor, textShadow,
                 centerText: true);
 
             renderTarget.Transform = currentTransform;

--- a/Helpers/YamlConverters.cs
+++ b/Helpers/YamlConverters.cs
@@ -290,6 +290,8 @@ namespace MapAssist.Helpers
                 emitter.Emit(new Scalar(null, node.LabelFontSize.ToString()));
                 emitter.Emit(new Scalar(null, "LabelFont"));
                 emitter.Emit(new Scalar(null, node.LabelFont.ToString()));
+                emitter.Emit(new Scalar(null, "LabelTextShadow"));
+                emitter.Emit(new Scalar(null, node.LabelTextShadow.ToString()));
             }
         }
 

--- a/Helpers/YamlConverters.cs
+++ b/Helpers/YamlConverters.cs
@@ -291,7 +291,7 @@ namespace MapAssist.Helpers
                 emitter.Emit(new Scalar(null, "LabelFont"));
                 emitter.Emit(new Scalar(null, node.LabelFont.ToString()));
                 emitter.Emit(new Scalar(null, "LabelTextShadow"));
-                emitter.Emit(new Scalar(null, node.LabelTextShadow.ToString()));
+                emitter.Emit(new Scalar(null, node.LabelTextShadow.ToString().ToLower()));
             }
         }
 

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -189,6 +189,9 @@ public class RenderingConfiguration
 
     [YamlMember(Alias = "BuffSize", ApplyNamingConventions = false)]
     public double BuffSize { get; set; }
+
+    [YamlMember(Alias = "TextShadow", ApplyNamingConventions = false)]
+    public bool TextShadow { get; set; }
 }
 
 public class HotkeyConfiguration
@@ -224,7 +227,10 @@ public class GameInfoConfiguration
     public string LabelFont { get; set; }
 
     [YamlMember(Alias = "LabelFontSize", ApplyNamingConventions = false)]
-    public int LabelFontSize { get; set; }
+    public double LabelFontSize { get; set; }
+
+    [YamlMember(Alias = "LabelFontShadow", ApplyNamingConventions = false)]
+    public bool LabelFontShadow { get; set; }
 }
 
 public class ItemLogConfiguration
@@ -252,4 +258,7 @@ public class ItemLogConfiguration
 
     [YamlMember(Alias = "LabelFontSize", ApplyNamingConventions = false)]
     public double LabelFontSize { get; set; }
+
+    [YamlMember(Alias = "LabelFontShadow", ApplyNamingConventions = false)]
+    public bool LabelFontShadow { get; set; }
 }

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -189,9 +189,6 @@ public class RenderingConfiguration
 
     [YamlMember(Alias = "BuffSize", ApplyNamingConventions = false)]
     public double BuffSize { get; set; }
-
-    [YamlMember(Alias = "TextShadow", ApplyNamingConventions = false)]
-    public bool TextShadow { get; set; }
 }
 
 public class HotkeyConfiguration
@@ -229,8 +226,8 @@ public class GameInfoConfiguration
     [YamlMember(Alias = "LabelFontSize", ApplyNamingConventions = false)]
     public double LabelFontSize { get; set; }
 
-    [YamlMember(Alias = "LabelFontShadow", ApplyNamingConventions = false)]
-    public bool LabelFontShadow { get; set; }
+    [YamlMember(Alias = "LabelTextShadow", ApplyNamingConventions = false)]
+    public bool LabelTextShadow { get; set; }
 }
 
 public class ItemLogConfiguration
@@ -259,6 +256,6 @@ public class ItemLogConfiguration
     [YamlMember(Alias = "LabelFontSize", ApplyNamingConventions = false)]
     public double LabelFontSize { get; set; }
 
-    [YamlMember(Alias = "LabelFontShadow", ApplyNamingConventions = false)]
-    public bool LabelFontShadow { get; set; }
+    [YamlMember(Alias = "LabelTextShadow", ApplyNamingConventions = false)]
+    public bool LabelTextShadow { get; set; }
 }

--- a/Settings/PointOfInterestRendering.cs
+++ b/Settings/PointOfInterestRendering.cs
@@ -66,6 +66,9 @@ namespace MapAssist.Settings
         [YamlMember(Alias = "LabelFontSize", ApplyNamingConventions = false)]
         public float LabelFontSize { get; set; }
 
+        [YamlMember(Alias = "LabelFontShadow", ApplyNamingConventions = false)]
+        public bool LabelFontShadow { get; set; }
+
         public bool CanDrawLine()
         {
             return LineColor != Color.Transparent && LineThickness > 0;

--- a/Settings/PointOfInterestRendering.cs
+++ b/Settings/PointOfInterestRendering.cs
@@ -64,10 +64,10 @@ namespace MapAssist.Settings
         public string LabelFont { get; set; }
 
         [YamlMember(Alias = "LabelFontSize", ApplyNamingConventions = false)]
-        public float LabelFontSize { get; set; }
+        public double LabelFontSize { get; set; }
 
-        [YamlMember(Alias = "LabelFontShadow", ApplyNamingConventions = false)]
-        public bool LabelFontShadow { get; set; }
+        [YamlMember(Alias = "LabelTextShadow", ApplyNamingConventions = false)]
+        public bool LabelTextShadow { get; set; }
 
         public bool CanDrawLine()
         {


### PR DESCRIPTION
Text Shadows add a nice touch to map labels and may help slightly with readability

> ![shadow1](https://user-images.githubusercontent.com/10291543/148328618-95e579c1-6b0f-4155-a2f8-ee3e45cbd078.png)

The text shadow is implemented as a second DrawText each time drawing a text label.  It is Black, 60% opaque, and offset to 1/16th the font size

> ![shadow2](https://user-images.githubusercontent.com/10291543/148330925-9bc627b4-2856-43fc-b864-aca6f19e4fb2.png)
> Larger text to demonstrate relative shadow size

GUI - Main
* GroupBoxes to organize GameInfo and other settings
* Hunt IP is set to ReadOnly when "Show Game IP" is unchecked
* Added Font Button, Clear Font Button, and Text Shadow Checkbox

> ![gui1](https://user-images.githubusercontent.com/10291543/148328479-84774d6e-c2da-49ac-aff5-35b124bb2696.PNG)

GUI - Drawing
* Text Shadow Checkbox on each PointOfInterestRendering config

> ![gui2](https://user-images.githubusercontent.com/10291543/148328553-89df1929-5958-4217-bd36-4cfe6c114538.PNG)

GUI - Item Log
* Text Shadow Checkbox

> ![gui3](https://user-images.githubusercontent.com/10291543/148330665-c32f90de-629d-4eb7-bd86-5f0d857fa8e2.PNG)
