### PR TITLE
Defense and All Resist for Item Filter

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -863,63 +863,24 @@ namespace MapAssist.Helpers
             {
                 var item = ItemLog[i];
 
-                Color fontColor;
-                if (item == null || !Items.ItemColors.TryGetValue(item.ItemData.ItemQuality, out fontColor))
+                var fontColor = Items.ItemNameColor(item);
+                if (item == null || fontColor == Color.Empty)
                 {
                     // Invalid item quality
                     continue;
                 }
 
+                var itemName = Items.ItemLogDisplayName(item);
                 var font = CreateFont(gfx, MapAssistConfiguration.Loaded.ItemLog.LabelFont, (float)MapAssistConfiguration.Loaded.ItemLog.LabelFontSize);
-
-                var isEth = (item.ItemData.ItemFlags & ItemFlags.IFLAG_ETHEREAL) == ItemFlags.IFLAG_ETHEREAL;
-                var itemBaseName = Items.ItemNameDisplay(item.TxtFileNo);
-                var itemSpecialName = "";
-                var itemLabelExtra = "";
-
-                if (isEth)
-                {
-                    itemLabelExtra += "[Eth] ";
-                    if (fontColor == Color.White)
-                    {
-                        fontColor = Items.ItemColors[ItemQuality.SUPERIOR];
-                    }
-                }
-
-                if (item.Stats.TryGetValue(Stat.STAT_ITEM_NUMSOCKETS, out var numSockets))
-                {
-                    itemLabelExtra += "[" + numSockets + " S] ";
-                    if (fontColor == Color.White)
-                    {
-                        fontColor = Items.ItemColors[ItemQuality.SUPERIOR];
-                    }
-                }
-
-                if (itemBaseName.EndsWith(" Rune") || itemBaseName.StartsWith("Key of "))
-                {
-                    fontColor = Items.ItemColors[ItemQuality.CRAFT];
-                }
-
-                switch (item.ItemData.ItemQuality)
-                {
-                    case ItemQuality.UNIQUE:
-                        itemSpecialName = Items.UniqueName(item.TxtFileNo) + " ";
-                        break;
-                    case ItemQuality.SET:
-                        itemSpecialName = Items.SetName(item.TxtFileNo) + " ";
-                        break;
-                }
-
                 var position = anchor.Add(0, i * fontHeight);
                 var brush = CreateSolidBrush(gfx, fontColor, 1);
-                var text = itemLabelExtra + itemSpecialName + itemBaseName;
 
                 if (textShadow)
                 {
-                    gfx.DrawText(font, shadowBrush, position.X + shadowOffset, position.Y + shadowOffset, text);
+                    gfx.DrawText(font, shadowBrush, position.X + shadowOffset, position.Y + shadowOffset, itemName);
                 }
 
-                gfx.DrawText(font, brush, position, text);
+                gfx.DrawText(font, brush, position, itemName);
             }
         }
 

--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -72,10 +72,7 @@ namespace MapAssist.Helpers
                 var ethReqMet = (rule.Ethereal == null || rule.Ethereal == isEth);
                 if (!ethReqMet) { continue; }
 
-                if (qualityReqMet && socketReqMet && defenseReqMet && allResReqMet && ethReqMet)
-                {
-                    return true;
-                }
+                return true;
             }
 
             return false;

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -53,6 +53,7 @@ x-bases:
   - &merc-arm-base
     Ethereal: true
     Qualities: [normal, superior]
+    Defense: 680
     Sockets: [0, 3, 4]
   - &player-arm-base
     Ethereal: false
@@ -65,6 +66,7 @@ x-bases:
   - &pally-shield-base
     # Ethereal: true # Uncomment this if you need an ethereal shield base, or flip it to false for non-ethereal
     Qualities: [normal, superior]
+    AllResist: 25
     Sockets: [0, 4]
 
 # This ring rule will show all magic, rare, and unique rings

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -20,5 +20,7 @@ namespace MapAssist.Settings
         public ItemQuality[] Qualities { get; set; }
         public bool? Ethereal { get; set; }
         public int[] Sockets { get; set; }
+        public int? Defense { get; set; }
+        public int? AllResist { get; set; }
     }
 }


### PR DESCRIPTION
ItemFilter.yaml support for `Defense` and `AllResist`

![item-filter](https://user-images.githubusercontent.com/10291543/148410445-463d2934-8cb8-45ce-8fea-fe48c91d3afc.png)

Defenses will display on all Normal and Superior items in the item log.  

All Resist stat will display on Normal and Superior items in the item log if the item has All Resists > 0

Updated Compositor.DrawItemLog to move code over to Items class for getting the item name and item color.  Added Essences to list of items that have Orange (crafted) color name, and switched those checks to use the txtFileNo so it's localization-friendly (instead of checking for English string match)