### PR TITLE
Fix to reset map seed on game exit

### DIFF
--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -215,7 +215,7 @@ namespace MapAssist.Helpers
                         item.IsCached = false;
                     }
 
-                    var enableInventoryFilterCheck = item.IsIdentified && item.IsPlayerOwned && item.ItemMode != ItemMode.SOCKETED;
+                    var enableInventoryFilterCheck = item.IsIdentified && item.IsPlayerOwned;
 
                     item.Update();
 

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -225,7 +225,7 @@ namespace MapAssist.Helpers
                     if (item.UnitId == uint.MaxValue) continue;
 
                     item.IsPlayerOwned = _playerCubeOwnerID[_currentProcessId] != uint.MaxValue &&
-                        item.ItemData.dwOwnerID == _playerCubeOwnerID[_currentProcessId];
+                        item.ItemData.dwOwnerID == _playerCubeOwnerID[_currentProcessId] && !item.IsInSocket;
 
                     if (item.IsInStore)
                     {

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -215,7 +215,7 @@ namespace MapAssist.Helpers
                         item.IsCached = false;
                     }
 
-                    var enableInventoryFilterCheck = item.IsIdentified && item.IsPlayerOwned;
+                    var enableInventoryFilterCheck = item.IsIdentified && item.IsPlayerOwned && item.ItemMode != ItemMode.SOCKETED;
 
                     item.Update();
 

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -79,6 +79,11 @@ namespace MapAssist.Helpers
 
                 if (playerUnit == null)
                 {
+                    if (_lastMapSeeds.ContainsKey(_currentProcessId))
+                    {
+                        _lastMapSeeds[_currentProcessId] = 0;
+                    }
+
                     if (_errorThrown) return null;
 
                     _errorThrown = true;

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -77,7 +77,7 @@ namespace MapAssist.Types
         }
 
         private static bool CheckInventoryItem(UnitItem item, int processId) =>
-            item.IsIdentified && item.IsPlayerOwned && item.ItemMode != ItemMode.SOCKETED &&
+            item.IsIdentified && item.IsPlayerOwned &&
             !InventoryItemUnitIdsToSkip[processId].Contains(item.UnitId);
 
         private static bool CheckDroppedItem(UnitItem item, int processId) =>

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -77,7 +77,7 @@ namespace MapAssist.Types
         }
 
         private static bool CheckInventoryItem(UnitItem item, int processId) =>
-            item.IsIdentified && item.IsPlayerOwned &&
+            item.IsIdentified && item.IsPlayerOwned && item.ItemMode != ItemMode.SOCKETED &&
             !InventoryItemUnitIdsToSkip[processId].Contains(item.UnitId);
 
         private static bool CheckDroppedItem(UnitItem item, int processId) =>

--- a/Types/UnitItem.cs
+++ b/Types/UnitItem.cs
@@ -49,6 +49,8 @@ namespace MapAssist.Types
 
         public bool IsInStore => ItemModeMapped == ItemModeMapped.Vendor;
 
+        public bool IsInSocket => ItemModeMapped == ItemModeMapped.Socket;
+
         public bool IsAnyPlayerHolding
         {
             get


### PR DESCRIPTION
Reset cached map seed when player exits game.  This appears to fix Vendor Inventory scans for Offline games.

Every time I exit a game (online or offline) I see `Player unit not found.` in the logs, so I figured this might help to reset the last map seed at that time.

I think the "ghost runes" is coming from a socketed item that the player is wearing.  As I'm working with a user who seems to have the problem often but I can't reproduce it.  The user is testing my branch and it seems like the additional socket check fixes it 🤷‍♂️ 