### PR TITLE
Added partial tile offset in Unit/Path Struct

### DIFF
--- a/Structs/Path.cs
+++ b/Structs/Path.cs
@@ -25,7 +25,9 @@ namespace MapAssist.Structs
     [StructLayout(LayoutKind.Explicit)]
     public struct Path
     {
+        [FieldOffset(0x00)] public ushort XOffset;
         [FieldOffset(0x02)] public ushort DynamicX;
+        [FieldOffset(0x04)] public ushort YOffset;
         [FieldOffset(0x06)] public ushort DynamicY;
         [FieldOffset(0x10)] public ushort StaticX;
         [FieldOffset(0x14)] public ushort StaticY;

--- a/Types/Path.cs
+++ b/Types/Path.cs
@@ -44,8 +44,13 @@ namespace MapAssist.Types
             return this;
         }
 
-        public ushort DynamicX => _path.DynamicX;
-        public ushort DynamicY => _path.DynamicY;
+        public float CalcFloatPos(ushort DynamicVal, ushort OffsetVal)
+        {
+            return DynamicVal + ((float)OffsetVal / 65535);
+        }
+
+        public float DynamicX => CalcFloatPos(_path.DynamicX, _path.XOffset);
+        public float DynamicY => CalcFloatPos(_path.DynamicY, _path.YOffset);
         public ushort StaticX => _path.StaticX;
         public ushort StaticY => _path.StaticY;
         public Room Room => new Room(_path.pRoom);

--- a/Types/UnitAny.cs
+++ b/Types/UnitAny.cs
@@ -34,8 +34,8 @@ namespace MapAssist.Types
         public uint TxtFileNo => Struct.TxtFileNo;
         public Area Area { get; private set; }
         public Point Position => new Point(X, Y);
-        public ushort X => IsMovable ? Path.DynamicX : Path.StaticX;
-        public ushort Y => IsMovable ? Path.DynamicY : Path.StaticY;
+        public float X => IsMovable ? Path.DynamicX : (float)Path.StaticX;
+        public float Y => IsMovable ? Path.DynamicY : (float)Path.StaticY;
         public StatListStruct StatsStruct { get; private set; }
         public Dictionary<Stat, Dictionary<ushort, int>> StatLayers { get; private set; }
         public Dictionary<Stat, int> Stats { get; private set; }


### PR DESCRIPTION
In Path, there's also XOffset and YOffset. This is a 2 byte value giving a range of 0-65535 which is like a percentage of a game tile.
So when the player is stationary it will be 32767, which is 0.5 of a game tile since they're standing in the middle of it.
```
        [FieldOffset(0x00)] public ushort XOffset;
        [FieldOffset(0x02)] public ushort DynamicX;
        [FieldOffset(0x04)] public ushort YOffset;
        [FieldOffset(0x06)] public ushort DynamicY;
```

Instead of Unit position being an integer game tile e.g. `5153, 4228` , it's now `5153.5, 4228.5`.
That extra precision allows for a more fluid movement of the game map.

Note: Not sure if I calculated it in the cleanest way.