### PR TITLE
Check for unit type match when applying hover on units

### DIFF
--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -338,7 +338,7 @@ namespace MapAssist.Helpers
 
                 if (lastHoverData.IsHovered)
                 {
-                    var units = allUnits.Where(x => x.UnitId == lastHoverData.UnitId).ToArray();
+                    var units = allUnits.Where(x => x.UnitId == lastHoverData.UnitId && x.UnitType == lastHoverData.UnitType).ToArray();
                     if (units.Length > 0) units[0].IsHovered = true;
                 }
 


### PR DESCRIPTION
I noticed that sometimes this where is returning more than one result, for example a monster AND object with same UnitId and this is always setting the first item found to hover, but we can match it better if we also use the UnitType to match them.