### PR TITLE
High DPI awareness

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -231,3 +231,5 @@ GameInfo:
   LabelTextShadow: true
 D2Path: ''
 LanguageCode: enUS
+DPIAware: false
+

--- a/ConfigEditor.Designer.cs
+++ b/ConfigEditor.Designer.cs
@@ -171,6 +171,8 @@
             this.btnAddHidden = new System.Windows.Forms.Button();
             this.lstHidden = new System.Windows.Forms.ListBox();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
+            this.groupBox8 = new System.Windows.Forms.GroupBox();
+            this.chkDPIAware = new System.Windows.Forms.CheckBox();
             this.tabControl1.SuspendLayout();
             this.tabPage5.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -204,6 +206,7 @@
             this.grpHotkeys.SuspendLayout();
             this.tabPage4.SuspendLayout();
             this.groupBox2.SuspendLayout();
+            this.groupBox8.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabControl1
@@ -1806,6 +1809,7 @@
             // tabPage4
             // 
             this.tabPage4.Controls.Add(this.groupBox2);
+            this.tabPage4.Controls.Add(this.groupBox8);
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Size = new System.Drawing.Size(359, 325);
@@ -1852,6 +1856,29 @@
             this.lstHidden.Name = "lstHidden";
             this.lstHidden.Size = new System.Drawing.Size(293, 160);
             this.lstHidden.TabIndex = 0;
+            // 
+            // groupBox8
+            // 
+            this.groupBox8.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.groupBox8.Controls.Add(this.chkDPIAware);
+            this.groupBox8.Location = new System.Drawing.Point(11, 200);
+            this.groupBox8.Name = "groupBox8";
+            this.groupBox8.Size = new System.Drawing.Size(335, 54);
+            this.groupBox8.TabIndex = 29;
+            this.groupBox8.TabStop = false;
+            this.groupBox8.Text = "HiDPI";
+            // 
+            // chkDPIAware
+            // 
+            this.chkDPIAware.AutoSize = true;
+            this.chkDPIAware.Location = new System.Drawing.Point(10, 26);
+            this.chkDPIAware.Name = "chkDPIAware";
+            this.chkDPIAware.Size = new System.Drawing.Size(120, 16);
+            this.chkDPIAware.TabIndex = 27;
+            this.chkDPIAware.Text = "DPI Awareness(*)";
+            this.chkDPIAware.UseVisualStyleBackColor = true;
+            this.chkDPIAware.CheckedChanged += new System.EventHandler(this.chkDPIAware_CheckedChanged);
+
             // 
             // ConfigEditor
             // 
@@ -1912,6 +1939,8 @@
             this.grpHotkeys.PerformLayout();
             this.tabPage4.ResumeLayout(false);
             this.groupBox2.ResumeLayout(false);
+            this.groupBox8.ResumeLayout(false);
+            this.groupBox8.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -2060,5 +2089,7 @@
         private System.Windows.Forms.CheckBox chkShowGameTimer;
         private System.Windows.Forms.TextBox txtHideMapKey;
         private System.Windows.Forms.Label lblHideMapKey;
+        private System.Windows.Forms.GroupBox groupBox8;
+        private System.Windows.Forms.CheckBox chkDPIAware;
     }
 }

--- a/ConfigEditor.cs
+++ b/ConfigEditor.cs
@@ -155,6 +155,7 @@ namespace MapAssist
             {
                 lstHidden.Items.Add(AreaExtensions.Name(area));
             }
+            chkDPIAware.Checked = MapAssistConfiguration.Loaded.DPIAware;
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
@@ -865,6 +866,11 @@ namespace MapAssist
                 backgroundColor.B * backgroundColor.B * .114);
 
             return brightness > 128 ? Color.Black : Color.White;
+        }
+
+        private void chkDPIAware_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.DPIAware = chkDPIAware.Checked;
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -27,9 +27,11 @@ using System.Diagnostics;
 using NLog;
 using MapAssist.Helpers;
 using MapAssist.Types;
+using System.Runtime.InteropServices;
 
 namespace MapAssist
 {
+
     static class Program
     {
         private static readonly string githubSha = "GITHUB_SHA";
@@ -76,6 +78,11 @@ namespace MapAssist
                     if (githubSha.Length == 40)
                     {
                         _log.Info($"Running from commit {githubSha}");
+                    }
+
+                    if (MapAssistConfiguration.Loaded.DPIAware)
+                    {
+                        SetProcessDPIAware();
                     }
 
                     Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
@@ -332,5 +339,9 @@ namespace MapAssist
 
             Application.Exit();
         }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern bool SetProcessDPIAware();
     }
+
 }

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -70,6 +70,9 @@ namespace MapAssist.Settings
 
         [YamlMember(Alias = "LanguageCode", ApplyNamingConventions = false)]
         public Locale LanguageCode { get; set; }
+
+        [YamlMember(Alias = "DPIAware", ApplyNamingConventions = false)]
+        public bool DPIAware { get; set; }
     }
 
     public class MapColorConfiguration
@@ -229,6 +232,7 @@ public class RenderingConfiguration
 
     [YamlMember(Alias = "LinesMode", ApplyNamingConventions = false)]
     public MapLinesMode LinesMode { get; set; }
+
 }
 
 public class HotkeyConfiguration


### PR DESCRIPTION
Support high DPI awareness. When enabled,  in high DPI the fonts are smoother.
When enabled in high DPI screen, icon size for POI will be smaller.
So it is disabled by default to avoid confusion.


Click on the figures to see difference in original size.
Figure 1: DPIAware disbled; zoom = 1


![nodpi](https://user-images.githubusercontent.com/86044546/156863429-97c94231-8dd0-4dd6-9155-66328749b24e.jpg)

Figure 2: DPIAware enabled; zoom = -3.5. My screen is 200% scaled, so need adjust it to get same zoom level.
![dpi](https://user-images.githubusercontent.com/86044546/156863440-ad7f2024-248b-4d27-aa97-327d883acd51.jpg)

