### PR TITLE
fix: vendor white items

### DIFF
--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -88,7 +88,7 @@ namespace MapAssist.Types
 
         public static bool CheckVendorItem(UnitItem item, int processId) =>
             MapAssistConfiguration.Loaded.ItemLog.CheckVendorItems &&
-            item.IsIdentified && item.IsInStore &&
+            item.IsInStore &&
             !ItemUnitIdsSeen[processId].Contains(item.UnitId) &&
             !ItemUnitIdsToSkip[processId].Contains(item.UnitId);
 


### PR DESCRIPTION
![vendor](https://user-images.githubusercontent.com/10291543/156868309-5d6fd676-e425-4503-bc5b-674cbd292ed2.png)

Checking `item.IsIdentified` in `CheckVendorItem` is the only thing preventing Vendor alerts for normal and superior items.

I tested the three types of item alerts after making this change and all looks good to me