### PR TITLE
Stash Tab

### DIFF
--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -300,7 +300,6 @@ namespace MapAssist.Helpers
                         Items.LogItem(item, _currentProcessId);
                     }
 
-
                     if (item.Item == Item.HoradricCube)
                     {
                         Items.ItemUnitIdsToSkip[_currentProcessId].Add(item.UnitId);
@@ -308,7 +307,6 @@ namespace MapAssist.Helpers
 
                     rawItemUnits.Add(item);
                 }
-                _log.Info($"------");
 
                 var itemList = Items.ItemLog[_currentProcessId].Select(item =>
                 {

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -117,6 +117,10 @@ namespace MapAssist.Helpers
                 {
                     PlayerUnits[_currentProcessId] = playerUnit;
                 }
+                var stashTabOrder = rawPlayerUnits
+                    .Where(o => o.StateList.Contains(State.STATE_SHAREDSTASH) || o.IsPlayer)
+                    .OrderBy(o => o.Struct.UnkSortStashesBy)
+                    .Select(o => o.UnitId).ToList();
 
                 var levelId = playerUnit.Area;
 
@@ -248,6 +252,15 @@ namespace MapAssist.Helpers
 
                     item.Update();
 
+                    if (item.ItemModeMapped == ItemModeMapped.Stash)
+                    {
+                        var stashIndex = stashTabOrder.FindIndex(a => a == item.ItemData.dwOwnerID);
+                        if (stashIndex >= 0)
+                        {
+                            item.StashTab = (StashTab)stashIndex+1;
+                        }
+                    }
+
                     cache[item.UnitId] = item;
 
                     if (item.ItemModeMapped == ItemModeMapped.Ground)
@@ -287,6 +300,7 @@ namespace MapAssist.Helpers
                         Items.LogItem(item, _currentProcessId);
                     }
 
+
                     if (item.Item == Item.HoradricCube)
                     {
                         Items.ItemUnitIdsToSkip[_currentProcessId].Add(item.UnitId);
@@ -294,6 +308,7 @@ namespace MapAssist.Helpers
 
                     rawItemUnits.Add(item);
                 }
+                _log.Info($"------");
 
                 var itemList = Items.ItemLog[_currentProcessId].Select(item =>
                 {
@@ -355,6 +370,7 @@ namespace MapAssist.Helpers
                     MainWindowHandle = GameManager.MainWindowHandle,
                     PlayerName = playerUnit.Name,
                     PlayerUnit = playerUnit,
+                    StashTabOrder = stashTabOrder,
                     Players = playerList,
                     Corpses = corpseList,
                     Monsters = monsterList,

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -368,7 +368,6 @@ namespace MapAssist.Helpers
                     MainWindowHandle = GameManager.MainWindowHandle,
                     PlayerName = playerUnit.Name,
                     PlayerUnit = playerUnit,
-                    StashTabOrder = stashTabOrder,
                     Players = playerList,
                     Corpses = corpseList,
                     Monsters = monsterList,

--- a/Structs/UnitAny.cs
+++ b/Structs/UnitAny.cs
@@ -41,6 +41,7 @@ namespace MapAssist.Structs
         [FieldOffset(0xC4)] public ushort X;
 
         [FieldOffset(0xC6)] public ushort Y;
+        [FieldOffset(0xD8)] public readonly uint UnkSortStashesBy;
         [FieldOffset(0x100)] public IntPtr pSkills;
         [FieldOffset(0x150)] public IntPtr pListNext;
         [FieldOffset(0x158)] public IntPtr pRoomNext;

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -2647,4 +2647,13 @@ namespace MapAssist.Types
         Elite,
         NotApplicable
     }
+
+    public enum StashTab
+    {
+        None,
+        Personal,
+        Shared1,
+        Shared2,
+        Shared3
+    }
 }

--- a/Types/Stats.cs
+++ b/Types/Stats.cs
@@ -422,6 +422,9 @@ namespace MapAssist.Types
         STATE_PASSIVE_RESISTCOLD,
         STATE_PASSIVE_RESISTLTNG,
         STATE_UBERMINION,
+        STATE_COOLDOWN,
+        STATE_SHAREDSTASH,
+        STATE_HIDEDEAD
     };
 
     public static class Stats

--- a/Types/UnitItem.cs
+++ b/Types/UnitItem.cs
@@ -53,6 +53,8 @@ namespace MapAssist.Types
 
         public bool IsInSocket => ItemModeMapped == ItemModeMapped.Socket;
 
+        public StashTab StashTab { get; set; } = StashTab.None;
+
         public bool IsAnyPlayerHolding
         {
             get


### PR DESCRIPTION
Each item will now have a `StashTab` property

How it works:
- Each shared stash tab is a player unit with the state 'STATE_SHAREDSTASH'
- For those 3 player units and the actual player unit the `UnkSortStashesBy` value gives a value that is in order of the tabs.
(They aren't sequential, just ascending, and change each game session even for the same player).
- So it sorts those player units by `UnkSortStashesBy` and then marries the `UnitId` value for each playerunit to the `ItemData.dwOwnerId` for each item.