### PR TITLE
Adjust check for directory

### DIFF
--- a/Helpers/MapApi.cs
+++ b/Helpers/MapApi.cs
@@ -112,7 +112,10 @@ namespace MapAssist.Helpers
             var providedPath = MapAssistConfiguration.Loaded.D2LoDPath;
             if (!string.IsNullOrEmpty(providedPath))
             {
-                if (Path.HasExtension(providedPath))
+                //Set attributes of directory used
+                var attributes = File.GetAttributes($@"{providedPath}");
+                //If this flag is found, path is a directory. Otherwise it is a file
+                if (!attributes.HasFlag(FileAttributes.Directory))
                 {
                     var config1 = new ConfigEditor();
                     MessageBox.Show("Provided D2 LoD path is not set to a directory." + Environment.NewLine + Environment.NewLine + "Please provide a path to a D2 LoD 1.13c installation and restart MapAssist.");


### PR DESCRIPTION
The check for "HasExtension" fails when a directory has a period in the name, which probably isn't uncommon (especially for people who mod). A directory with the name "Diablo II - 1.13", for instance fails this check. I have changed it to simply check for a flag that is in there already.