### PR TITLE
Adjust check for directory

### DIFF
--- a/Helpers/MapApi.cs
+++ b/Helpers/MapApi.cs
@@ -112,7 +112,10 @@ namespace MapAssist.Helpers
             var providedPath = MapAssistConfiguration.Loaded.D2LoDPath;
             if (!string.IsNullOrEmpty(providedPath))
             {
-                if (Path.HasExtension(providedPath))
+                //Set attributes of directory used
+                var attributes = File.GetAttributes($@"{providedPath}");
+                //If this flag is found, path is a directory. Otherwise it is a file
+                if (!attributes.HasFlag(FileAttributes.Directory))
                 {
                     var config1 = new ConfigEditor();
                     MessageBox.Show("Provided D2 LoD path is not set to a directory." + Environment.NewLine + Environment.NewLine + "Please provide a path to a D2 LoD 1.13c installation and restart MapAssist.");


### PR DESCRIPTION
The check for Path.HasExtension on the FindD2LoD function fails when a user has a period in the name of their directory, which isn't uncommon (especially for those who mod). For instance, the directory "Diablo II - 1.13" fails this check, even though it should be fine. I have adjusted the check to with the "HasFlag" on the file attributes of the path and check for "FileAttributes.Directory".