### PR TITLE
Bug fix in ConfigEditor.cs

### DIFF
--- a/ConfigEditor.cs
+++ b/ConfigEditor.cs
@@ -564,8 +564,8 @@ namespace MapAssist
         private void btnFont_Click(object sender, EventArgs e)
         {
             dynamic labelProp = SelectedProperty.GetValue(MapAssistConfiguration.Loaded.MapConfiguration, null);
-            var labelFont = labelProp.LabelFont;
-            var labelSize = labelProp.LabelFontSize;
+            var labelFont = (string) labelProp.LabelFont;
+            var labelSize = (float) labelProp.LabelFontSize;
             if (labelFont == null)
             {
                 labelFont = "Helvetica";


### PR DESCRIPTION
Fixed a large bug with the "Font" button contained in every Label tab for Drawing settings.  Needed an explicit cast.

Error:
"The best overloaded method match for 'System.Drawing.Font.Font(System.Drawing.FontFamily, float, System.Drawing.FontStyle)' has some invalid arguments"

(btnFont_Click at ConfigEditor.cs line 575)