### PR TITLE
[Fix] unicode player name broken issue

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Text;
 using Color = System.Drawing.Color;
 using Pen = System.Drawing.Pen;
 
@@ -292,7 +293,8 @@ namespace MapAssist.Helpers
 
                     if (MapAssistConfiguration.Loaded.MapConfiguration.Portal.CanDrawLabel(destinationArea))
                     {
-                        var playerName = !string.IsNullOrWhiteSpace(gameObject.ObjectData.Owner) ? gameObject.ObjectData.Owner : null;
+                        var playerNameUnicode = Encoding.UTF8.GetString(gameObject.ObjectData.Owner);
+                        var playerName = !string.IsNullOrWhiteSpace(playerNameUnicode) ? playerNameUnicode : null;
                         var label = destinationArea.PortalLabel(_gameData.Difficulty, playerName);
 
                         if (string.IsNullOrWhiteSpace(label) || label == "None") continue;

--- a/Structs/ObjectData.cs
+++ b/Structs/ObjectData.cs
@@ -34,8 +34,8 @@ namespace MapAssist.Structs
         public IntPtr pShrineTxt;
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0x20)]
         private byte[] unk2;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
-        public string Owner;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0x2D)]
+        public byte[] Owner; 
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/Types/UnitPlayer.cs
+++ b/Types/UnitPlayer.cs
@@ -27,7 +27,7 @@ namespace MapAssist.Types
             {
                 using (var processContext = GameManager.GetProcessContext())
                 {
-                    Name = Encoding.ASCII.GetString(processContext.Read<byte>(Struct.pUnitData, 16)).TrimEnd((char)0);
+                    Name = Encoding.UTF8.GetString(processContext.Read<byte>(Struct.pUnitData, 45)).TrimEnd((char)0);
                     Act = new Act(Struct.pAct);
                     //Inventory = processContext.Read<Inventory>(Struct.ptrInventory);
                     Skills = new Skills(Struct.pSkills);


### PR DESCRIPTION
## Description
1. portal player name broken
![image 001](https://user-images.githubusercontent.com/52227539/166128665-f2c15973-d6be-4986-8a2c-e5fb302ea6e2.jpg) 
fixed ↓
![image 002](https://user-images.githubusercontent.com/52227539/166128666-25d22a5d-971f-43f7-b253-ec684b27cdb0.jpg)
2. player name Corpse broken
![image 003](https://user-images.githubusercontent.com/52227539/166128667-d6e46be3-a56d-4345-9579-93838f94f493.jpg)
fixed ↓
![image 004](https://user-images.githubusercontent.com/52227539/166128668-63408a17-539b-4e2b-985a-397192a497c3.jpg)

