### PR TITLE
Adding Area Level to Item Filter

### DIFF
--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -200,6 +200,8 @@ namespace MapAssist.Helpers
                     throw new Exception("Game difficulty out of bounds.");
                 }
 
+                var areaLevel = levelId.Level(gameDifficulty);
+
                 // Players
                 var playerList = rawPlayerUnits.Where(x => x.UnitType == UnitType.Player && x.IsPlayer)
                     .Select(x => x.UpdateRosterEntry(rosterData)).ToArray()
@@ -309,7 +311,7 @@ namespace MapAssist.Helpers
                     var checkVendorItem = Items.CheckVendorItem(item, _currentProcessId);
                     if (item.IsValidItem && (checkDroppedItem || checkVendorItem || checkInventoryItem))
                     {
-                        Items.LogItem(item, _currentProcessId);
+                        Items.LogItem(item, areaLevel, _currentProcessId);
                     }
 
                     if (item.Item == Item.HoradricCube)

--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -27,7 +27,7 @@ namespace MapAssist.Helpers
 {
     public static class LootFilter
     {
-        public static (bool, ItemFilter) Filter(UnitItem item)
+        public static (bool, ItemFilter) Filter(UnitItem item, int areaLevel)
         {
             // Skip low quality items
             var lowQuality = (item.ItemData.ItemFlags & ItemFlags.IFLAG_LOWQUALITY) == ItemFlags.IFLAG_LOWQUALITY;
@@ -57,6 +57,7 @@ namespace MapAssist.Helpers
                     ["Qualities"] = () => rule.Qualities.Contains(item.ItemData.ItemQuality),
                     ["Sockets"] = () => rule.Sockets.Contains(Items.GetItemStat(item, Stats.Stat.NumSockets)),
                     ["Ethereal"] = () => ((item.ItemData.ItemFlags & ItemFlags.IFLAG_ETHEREAL) == ItemFlags.IFLAG_ETHEREAL) == rule.Ethereal,
+                    ["AreaLevel"] = () => areaLevel >= rule.AreaLevel,
                     ["AllAttributes"] = () => Items.GetItemStatAllAttributes(item) >= rule.AllAttributes,
                     ["AllResist"] = () => Items.GetItemStatResists(item, false) >= rule.AllResist,
                     ["SumResist"] = () => Items.GetItemStatResists(item, true) >= rule.SumResist,

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -386,6 +386,8 @@ Amulet:
 
 Ring:
   - Qualities: [rare, unique]
+  - Qualities: magic
+    Area Level: 85
 
 Jewel:
   - Qualities: [magic, rare, unique]

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -239,6 +239,9 @@ namespace MapAssist.Settings
 
         [YamlMember(Alias = "Enhanced Damage")]
         public int? EnhancedDamage { get; set; }
+
+        [YamlMember(Alias = "Area Level")]
+        public int? AreaLevel { get; set; }
     }
 
     public static class ItemFilterExtensions

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -37,7 +37,7 @@ namespace MapAssist.Types
         public static Dictionary<int, List<ItemLogEntry>> ItemLog = new Dictionary<int, List<ItemLogEntry>>();
         public static Dictionary<string, LocalizedObj> LocalizedItems = new Dictionary<string, LocalizedObj>();
 
-        public static void LogItem(UnitItem item, int processId)
+        public static void LogItem(UnitItem item, int areaLevel, int processId)
         {
             if (item.IsInStore)
             {
@@ -56,7 +56,7 @@ namespace MapAssist.Types
 
             ItemUnitIdsSeen[processId].Add(item.UnitId);
 
-            var (logItem, rule) = LootFilter.Filter(item);
+            var (logItem, rule) = LootFilter.Filter(item, areaLevel);
             if (!logItem) return;
 
             if (MapAssistConfiguration.Loaded.ItemLog.PlaySoundOnDrop && (rule == null || rule.PlaySoundOnDrop))


### PR DESCRIPTION
Allows the user to set alerts for items that drop in areas based on a minimum area level requirement

The Area level passed to `Items.LogItem()` is based on where the player is standing.  We can change that to use `item.Area.Level(gameDifficulty)` but I thought it would be better performance and minimal difference to base it on the where the player is standing instead of looking up the Area Level on each item