### PR TITLE
Add door indicators to map

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -196,6 +196,10 @@ MapConfiguration:
     IconColor: 132, 132, 132
     IconShape: Square
     IconSize: 4
+  Door:
+    IconColor: 132, 132, 132
+    IconShape: Kite
+    IconSize: 3
   Item:
     IconColor: DarkOrange
     IconShape: Ellipse

--- a/Helpers/PointOfInterestHandler.cs
+++ b/Helpers/PointOfInterestHandler.cs
@@ -120,6 +120,39 @@ namespace MapAssist.Helpers
             GameObject.JungleShrine5,
         };
 
+        private static readonly HashSet<GameObject> Doors = new HashSet<GameObject>
+        {
+            GameObject.DoorCathedralDouble,
+            GameObject.DoorCathedralLeft,
+            GameObject.DoorCathedralRight,
+            GameObject.DoorCourtyardLeft,
+            GameObject.DoorCourtyardRight,
+            GameObject.DoorGateLeft,
+            GameObject.DoorGateRight,
+            GameObject.DoorMonasteryDoubleRight,
+            GameObject.DoorWoodenLeft,
+            GameObject.DoorWoodenLeft2,
+            GameObject.DoorWoodenRight,
+            GameObject.IronGrateDoorLeft,
+            GameObject.IronGrateDoorRight,
+            GameObject.SlimeDoor1,
+            GameObject.SlimeDoor2,
+            GameObject.TombDoorLeft,
+            GameObject.TombDoorLeft2,
+            GameObject.TombDoorRight,
+            GameObject.TombDoorRight2,
+            GameObject.WoodenDoorLeft,
+            GameObject.WoodenDoorRight,
+            GameObject.WoodenGrateDoorLeft,
+            GameObject.WoodenGrateDoorRight,
+            GameObject.DoorByAct2Dock,
+            GameObject.AndarielDoor,
+            GameObject.ArreatSummitDoor,
+            GameObject.PenBreakableDoor,
+            GameObject.SecretDoor1,
+            GameObject.TrappDoor
+        };
+
         public static void UpdateLocalizationNames()
         {
             QuestObjects = new Dictionary<GameObject, string>
@@ -551,6 +584,20 @@ namespace MapAssist.Helpers
                             Position = point,
                             RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack,
                             Type = PoiType.ArmorWeapRack
+                        });
+                    }
+                }
+                else if (Doors.Contains(obj))
+                {
+                    foreach (var point in points)
+                    {
+                        pointsOfInterest.Add(new PointOfInterest
+                        {
+                            Area = areaData.Area,
+                            Label = obj.ToString(),
+                            Position = point,
+                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.Door,
+                            Type = PoiType.Door
                         });
                     }
                 }

--- a/Helpers/PointOfInterestHandler.cs
+++ b/Helpers/PointOfInterestHandler.cs
@@ -122,7 +122,6 @@ namespace MapAssist.Helpers
 
         private static readonly HashSet<GameObject> Doors = new HashSet<GameObject>
         {
-            GameObject.DoorCathedralDouble,
             GameObject.DoorCathedralLeft,
             GameObject.DoorCathedralRight,
             GameObject.DoorCourtyardLeft,
@@ -145,12 +144,9 @@ namespace MapAssist.Helpers
             GameObject.WoodenDoorRight,
             GameObject.WoodenGrateDoorLeft,
             GameObject.WoodenGrateDoorRight,
-            GameObject.DoorByAct2Dock,
             GameObject.AndarielDoor,
-            GameObject.ArreatSummitDoor,
             GameObject.PenBreakableDoor,
-            GameObject.SecretDoor1,
-            GameObject.TrappDoor
+            GameObject.SecretDoor1
         };
 
         public static void UpdateLocalizationNames()

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -161,6 +161,9 @@ namespace MapAssist.Settings
         [YamlMember(Alias = "ArmorWeapRack", ApplyNamingConventions = false)]
         public PointOfInterestRendering ArmorWeapRack { get; set; }
 
+        [YamlMember(Alias = "Door", ApplyNamingConventions = false)]
+        public PointOfInterestRendering Door { get; set; }
+
         [YamlMember(Alias = "Item", ApplyNamingConventions = false)]
         public PointOfInterestRendering Item { get; set; }
 

--- a/Types/PointOfInterest.cs
+++ b/Types/PointOfInterest.cs
@@ -62,6 +62,7 @@ namespace MapAssist.Types
         AreaPortal,
         Shrine,
         SuperChest,
-        ArmorWeapRack
+        ArmorWeapRack,
+        Door
     }
 }


### PR DESCRIPTION
Added basic functionality to map that displays an icon for any door that can be clicked to open or close (does not include displaying an icon for an opening that does not have a clickable door, i.e. Forgotten Tower levels)