### PR TITLE
Minor cleanups.

### DIFF
--- a/Forms/ConfigEditor.Designer.cs
+++ b/Forms/ConfigEditor.Designer.cs
@@ -171,6 +171,7 @@
             this.btnAddHidden = new System.Windows.Forms.Button();
             this.lstHidden = new System.Windows.Forms.ListBox();
             this.groupBoxAuthorizedWindowTitle = new System.Windows.Forms.GroupBox();
+            this.txtAuthorizedWindowTitle = new System.Windows.Forms.TextBox();
             this.btnRemoveAuthorizedWindowTitle = new System.Windows.Forms.Button();
             this.btnAddAuthorizedWindowTitle = new System.Windows.Forms.Button();
             this.lstAuthorizedWindowTitle = new System.Windows.Forms.ListBox();
@@ -178,7 +179,6 @@
             this.label3 = new System.Windows.Forms.Label();
             this.chkDPIAware = new System.Windows.Forms.CheckBox();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
-            this.txtAuthorizedWindowTitle = new System.Windows.Forms.TextBox();
             this.tabControl1.SuspendLayout();
             this.tabPage5.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -218,6 +218,7 @@
             // 
             // tabControl1
             // 
+            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl1.Controls.Add(this.tabPage5);
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage3);
@@ -228,7 +229,7 @@
             this.tabControl1.Location = new System.Drawing.Point(12, 12);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(367, 351);
+            this.tabControl1.Size = new System.Drawing.Size(420, 351);
             this.tabControl1.TabIndex = 0;
             this.tabControl1.TabStop = false;
             // 
@@ -239,19 +240,20 @@
             this.tabPage5.Controls.Add(this.grpGameInfo);
             this.tabPage5.Location = new System.Drawing.Point(4, 22);
             this.tabPage5.Name = "tabPage5";
-            this.tabPage5.Size = new System.Drawing.Size(359, 325);
+            this.tabPage5.Size = new System.Drawing.Size(412, 325);
             this.tabPage5.TabIndex = 4;
             this.tabPage5.Text = "Main";
             this.tabPage5.UseVisualStyleBackColor = true;
             // 
             // groupBox5
             // 
+            this.groupBox5.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox5.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.groupBox5.Controls.Add(this.cboLanguage);
             this.groupBox5.Controls.Add(this.label11);
             this.groupBox5.Location = new System.Drawing.Point(11, 256);
             this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(335, 58);
+            this.groupBox5.Size = new System.Drawing.Size(388, 58);
             this.groupBox5.TabIndex = 25;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "Translation";
@@ -277,29 +279,32 @@
             // 
             // groupBox4
             // 
+            this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox4.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.groupBox4.Controls.Add(this.txtD2Path);
             this.groupBox4.Controls.Add(this.btnBrowseD2Location);
             this.groupBox4.Controls.Add(this.label1);
             this.groupBox4.Location = new System.Drawing.Point(11, 172);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(335, 69);
+            this.groupBox4.Size = new System.Drawing.Size(388, 69);
             this.groupBox4.TabIndex = 24;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "D2 LOD 1.13c Path";
             // 
             // txtD2Path
             // 
+            this.txtD2Path.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.txtD2Path.Enabled = false;
             this.txtD2Path.Location = new System.Drawing.Point(10, 23);
             this.txtD2Path.Name = "txtD2Path";
-            this.txtD2Path.Size = new System.Drawing.Size(230, 20);
+            this.txtD2Path.Size = new System.Drawing.Size(283, 20);
             this.txtD2Path.TabIndex = 7;
             this.txtD2Path.TextChanged += new System.EventHandler(this.txtD2Path_TextChanged);
             // 
             // btnBrowseD2Location
             // 
-            this.btnBrowseD2Location.Location = new System.Drawing.Point(251, 20);
+            this.btnBrowseD2Location.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnBrowseD2Location.Location = new System.Drawing.Point(304, 20);
             this.btnBrowseD2Location.Name = "btnBrowseD2Location";
             this.btnBrowseD2Location.Size = new System.Drawing.Size(75, 23);
             this.btnBrowseD2Location.TabIndex = 17;
@@ -320,6 +325,7 @@
             // 
             // grpGameInfo
             // 
+            this.grpGameInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.grpGameInfo.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.grpGameInfo.Controls.Add(this.chkShowAreaLevel);
             this.grpGameInfo.Controls.Add(this.cboGameInfoPosition);
@@ -335,13 +341,14 @@
             this.grpGameInfo.Controls.Add(this.chkShowGameName);
             this.grpGameInfo.Location = new System.Drawing.Point(11, 9);
             this.grpGameInfo.Name = "grpGameInfo";
-            this.grpGameInfo.Size = new System.Drawing.Size(335, 144);
+            this.grpGameInfo.Size = new System.Drawing.Size(388, 144);
             this.grpGameInfo.TabIndex = 23;
             this.grpGameInfo.TabStop = false;
             this.grpGameInfo.Text = "Game Info";
             // 
             // chkShowAreaLevel
             // 
+            this.chkShowAreaLevel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.chkShowAreaLevel.AutoSize = true;
             this.chkShowAreaLevel.Location = new System.Drawing.Point(192, 65);
             this.chkShowAreaLevel.Name = "chkShowAreaLevel";
@@ -353,16 +360,18 @@
             // 
             // cboGameInfoPosition
             // 
+            this.cboGameInfoPosition.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.cboGameInfoPosition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboGameInfoPosition.FormattingEnabled = true;
             this.cboGameInfoPosition.Location = new System.Drawing.Point(239, 111);
             this.cboGameInfoPosition.Name = "cboGameInfoPosition";
-            this.cboGameInfoPosition.Size = new System.Drawing.Size(87, 21);
+            this.cboGameInfoPosition.Size = new System.Drawing.Size(140, 21);
             this.cboGameInfoPosition.TabIndex = 36;
             this.cboGameInfoPosition.SelectedIndexChanged += new System.EventHandler(this.cboGameInfoPosition_SelectedIndexChanged);
             // 
             // lblGameInfoPosition
             // 
+            this.lblGameInfoPosition.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.lblGameInfoPosition.AutoSize = true;
             this.lblGameInfoPosition.Location = new System.Drawing.Point(189, 114);
             this.lblGameInfoPosition.Name = "lblGameInfoPosition";
@@ -383,6 +392,7 @@
             // 
             // chkShowOverlayFPS
             // 
+            this.chkShowOverlayFPS.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.chkShowOverlayFPS.AutoSize = true;
             this.chkShowOverlayFPS.Location = new System.Drawing.Point(192, 88);
             this.chkShowOverlayFPS.Name = "chkShowOverlayFPS";
@@ -429,6 +439,7 @@
             // 
             // chkShowAreaTimer
             // 
+            this.chkShowAreaTimer.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.chkShowAreaTimer.AutoSize = true;
             this.chkShowAreaTimer.Location = new System.Drawing.Point(192, 42);
             this.chkShowAreaTimer.Name = "chkShowAreaTimer";
@@ -451,6 +462,7 @@
             // 
             // chkShowArea
             // 
+            this.chkShowArea.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.chkShowArea.AutoSize = true;
             this.chkShowArea.Location = new System.Drawing.Point(192, 19);
             this.chkShowArea.Name = "chkShowArea";
@@ -478,13 +490,14 @@
             this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(359, 325);
+            this.tabPage1.Size = new System.Drawing.Size(412, 325);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Map";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
             // groupBox1
             // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.Controls.Add(this.chkMonsterHealthBar);
             this.groupBox1.Controls.Add(this.btnClearBorderColor);
             this.groupBox1.Controls.Add(this.btnClearWalkableColor);
@@ -510,7 +523,7 @@
             this.groupBox1.Controls.Add(this.chkToggleViaPanels);
             this.groupBox1.Location = new System.Drawing.Point(11, 9);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(335, 305);
+            this.groupBox1.Size = new System.Drawing.Size(388, 305);
             this.groupBox1.TabIndex = 21;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Rendering";
@@ -608,16 +621,18 @@
             // cboPosition
             // 
             this.cboPosition.AllowDrop = true;
+            this.cboPosition.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.cboPosition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboPosition.FormattingEnabled = true;
             this.cboPosition.Location = new System.Drawing.Point(222, 151);
             this.cboPosition.Name = "cboPosition";
-            this.cboPosition.Size = new System.Drawing.Size(107, 21);
+            this.cboPosition.Size = new System.Drawing.Size(160, 21);
             this.cboPosition.TabIndex = 6;
             this.cboPosition.SelectedIndexChanged += new System.EventHandler(this.cboPosition_SelectedIndexChanged);
             // 
             // mapZoom
             // 
+            this.mapZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.mapZoom.AutoSize = false;
             this.mapZoom.BackColor = System.Drawing.Color.White;
             this.mapZoom.LargeChange = 1;
@@ -625,7 +640,7 @@
             this.mapZoom.Maximum = 25;
             this.mapZoom.Minimum = 1;
             this.mapZoom.Name = "mapZoom";
-            this.mapZoom.Size = new System.Drawing.Size(213, 27);
+            this.mapZoom.Size = new System.Drawing.Size(266, 27);
             this.mapZoom.TabIndex = 13;
             this.mapZoom.Value = 1;
             this.mapZoom.Scroll += new System.EventHandler(this.mapZoom_Scroll);
@@ -633,13 +648,14 @@
             // 
             // mapSize
             // 
+            this.mapSize.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.mapSize.AutoSize = false;
             this.mapSize.BackColor = System.Drawing.Color.White;
             this.mapSize.LargeChange = 1;
             this.mapSize.Location = new System.Drawing.Point(79, 85);
             this.mapSize.Maximum = 16;
             this.mapSize.Name = "mapSize";
-            this.mapSize.Size = new System.Drawing.Size(213, 27);
+            this.mapSize.Size = new System.Drawing.Size(266, 27);
             this.mapSize.SmallChange = 25;
             this.mapSize.TabIndex = 10;
             this.mapSize.Scroll += new System.EventHandler(this.mapSize_Scroll);
@@ -647,9 +663,10 @@
             // 
             // lblMapZoomValue
             // 
+            this.lblMapZoomValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblMapZoomValue.AutoSize = true;
             this.lblMapZoomValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblMapZoomValue.Location = new System.Drawing.Point(298, 121);
+            this.lblMapZoomValue.Location = new System.Drawing.Point(351, 121);
             this.lblMapZoomValue.Name = "lblMapZoomValue";
             this.lblMapZoomValue.Size = new System.Drawing.Size(31, 13);
             this.lblMapZoomValue.TabIndex = 21;
@@ -668,9 +685,10 @@
             // 
             // lblMapSizeValue
             // 
+            this.lblMapSizeValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblMapSizeValue.AutoSize = true;
             this.lblMapSizeValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblMapSizeValue.Location = new System.Drawing.Point(298, 88);
+            this.lblMapSizeValue.Location = new System.Drawing.Point(351, 88);
             this.lblMapSizeValue.Name = "lblMapSizeValue";
             this.lblMapSizeValue.Size = new System.Drawing.Size(31, 13);
             this.lblMapSizeValue.TabIndex = 20;
@@ -679,13 +697,14 @@
             // 
             // iconOpacity
             // 
+            this.iconOpacity.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.iconOpacity.AutoSize = false;
             this.iconOpacity.BackColor = System.Drawing.Color.White;
             this.iconOpacity.LargeChange = 1;
             this.iconOpacity.Location = new System.Drawing.Point(79, 52);
             this.iconOpacity.Maximum = 20;
             this.iconOpacity.Name = "iconOpacity";
-            this.iconOpacity.Size = new System.Drawing.Size(213, 27);
+            this.iconOpacity.Size = new System.Drawing.Size(266, 27);
             this.iconOpacity.TabIndex = 3;
             this.iconOpacity.Scroll += new System.EventHandler(this.iconOpacity_Scroll);
             this.iconOpacity.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.IgnoreMouseWheel);
@@ -702,9 +721,10 @@
             // 
             // lblIconOpacityValue
             // 
+            this.lblIconOpacityValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblIconOpacityValue.AutoSize = true;
             this.lblIconOpacityValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblIconOpacityValue.Location = new System.Drawing.Point(298, 55);
+            this.lblIconOpacityValue.Location = new System.Drawing.Point(351, 55);
             this.lblIconOpacityValue.Name = "lblIconOpacityValue";
             this.lblIconOpacityValue.Size = new System.Drawing.Size(31, 13);
             this.lblIconOpacityValue.TabIndex = 5;
@@ -713,9 +733,10 @@
             // 
             // lblOpacityValue
             // 
+            this.lblOpacityValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblOpacityValue.AutoSize = true;
             this.lblOpacityValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblOpacityValue.Location = new System.Drawing.Point(298, 22);
+            this.lblOpacityValue.Location = new System.Drawing.Point(351, 22);
             this.lblOpacityValue.Name = "lblOpacityValue";
             this.lblOpacityValue.Size = new System.Drawing.Size(31, 13);
             this.lblOpacityValue.TabIndex = 3;
@@ -724,13 +745,14 @@
             // 
             // opacity
             // 
+            this.opacity.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.opacity.AutoSize = false;
             this.opacity.BackColor = System.Drawing.Color.White;
             this.opacity.LargeChange = 1;
             this.opacity.Location = new System.Drawing.Point(79, 19);
             this.opacity.Maximum = 20;
             this.opacity.Name = "opacity";
-            this.opacity.Size = new System.Drawing.Size(213, 27);
+            this.opacity.Size = new System.Drawing.Size(266, 27);
             this.opacity.TabIndex = 1;
             this.opacity.Scroll += new System.EventHandler(this.opacity_Scroll);
             this.opacity.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.IgnoreMouseWheel);
@@ -785,13 +807,14 @@
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(359, 325);
+            this.tabPage3.Size = new System.Drawing.Size(412, 325);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Overlay";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
             // groupBox7
             // 
+            this.groupBox7.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox7.Controls.Add(this.chkPotionBelt);
             this.groupBox7.Controls.Add(this.chkResistances);
             this.groupBox7.Controls.Add(this.chkExpProgress);
@@ -802,7 +825,7 @@
             this.groupBox7.Controls.Add(this.chkLife);
             this.groupBox7.Location = new System.Drawing.Point(11, 143);
             this.groupBox7.Name = "groupBox7";
-            this.groupBox7.Size = new System.Drawing.Size(335, 90);
+            this.groupBox7.Size = new System.Drawing.Size(388, 90);
             this.groupBox7.TabIndex = 25;
             this.groupBox7.TabStop = false;
             this.groupBox7.Text = "Player Info";
@@ -897,11 +920,12 @@
             // 
             // grpPresets
             // 
+            this.grpPresets.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.grpPresets.Controls.Add(this.lblMapLinesMode);
             this.grpPresets.Controls.Add(this.cboMapLinesMode);
             this.grpPresets.Location = new System.Drawing.Point(11, 263);
             this.grpPresets.Name = "grpPresets";
-            this.grpPresets.Size = new System.Drawing.Size(335, 51);
+            this.grpPresets.Size = new System.Drawing.Size(388, 51);
             this.grpPresets.TabIndex = 24;
             this.grpPresets.TabStop = false;
             this.grpPresets.Text = "Presets";
@@ -929,6 +953,7 @@
             // 
             // groupBox3
             // 
+            this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox3.Controls.Add(this.chkAlertLowerRes);
             this.groupBox3.Controls.Add(this.lblBuffSizeValue);
             this.groupBox3.Controls.Add(this.label5);
@@ -937,7 +962,7 @@
             this.groupBox3.Controls.Add(this.buffSize);
             this.groupBox3.Location = new System.Drawing.Point(11, 9);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(335, 107);
+            this.groupBox3.Size = new System.Drawing.Size(388, 107);
             this.groupBox3.TabIndex = 23;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Buffs";
@@ -955,9 +980,10 @@
             // 
             // lblBuffSizeValue
             // 
+            this.lblBuffSizeValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblBuffSizeValue.AutoSize = true;
             this.lblBuffSizeValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblBuffSizeValue.Location = new System.Drawing.Point(298, 21);
+            this.lblBuffSizeValue.Location = new System.Drawing.Point(351, 21);
             this.lblBuffSizeValue.Name = "lblBuffSizeValue";
             this.lblBuffSizeValue.Size = new System.Drawing.Size(31, 13);
             this.lblBuffSizeValue.TabIndex = 22;
@@ -996,13 +1022,14 @@
             // 
             // buffSize
             // 
+            this.buffSize.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.buffSize.AutoSize = false;
             this.buffSize.BackColor = System.Drawing.Color.White;
             this.buffSize.LargeChange = 1;
             this.buffSize.Location = new System.Drawing.Point(79, 18);
             this.buffSize.Maximum = 20;
             this.buffSize.Name = "buffSize";
-            this.buffSize.Size = new System.Drawing.Size(213, 27);
+            this.buffSize.Size = new System.Drawing.Size(266, 27);
             this.buffSize.TabIndex = 15;
             this.buffSize.Scroll += new System.EventHandler(this.buffSize_Scroll);
             this.buffSize.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.IgnoreMouseWheel);
@@ -1015,20 +1042,21 @@
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(359, 325);
+            this.tabPage2.Size = new System.Drawing.Size(412, 325);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Drawing";
             this.tabPage2.UseVisualStyleBackColor = true;
             // 
             // tabDrawing
             // 
+            this.tabDrawing.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.tabDrawing.Controls.Add(this.tabIcon);
             this.tabDrawing.Controls.Add(this.tabLabel);
             this.tabDrawing.Controls.Add(this.tabLine);
             this.tabDrawing.Location = new System.Drawing.Point(3, 33);
             this.tabDrawing.Name = "tabDrawing";
             this.tabDrawing.SelectedIndex = 0;
-            this.tabDrawing.Size = new System.Drawing.Size(353, 286);
+            this.tabDrawing.Size = new System.Drawing.Size(406, 286);
             this.tabDrawing.TabIndex = 10;
             this.tabDrawing.Visible = false;
             this.tabDrawing.SelectedIndexChanged += new System.EventHandler(this.tabDrawing_SelectedIndexChanged);
@@ -1050,7 +1078,7 @@
             this.tabIcon.Location = new System.Drawing.Point(4, 22);
             this.tabIcon.Name = "tabIcon";
             this.tabIcon.Padding = new System.Windows.Forms.Padding(3);
-            this.tabIcon.Size = new System.Drawing.Size(345, 260);
+            this.tabIcon.Size = new System.Drawing.Size(398, 260);
             this.tabIcon.TabIndex = 0;
             this.tabIcon.Text = "Icon";
             this.tabIcon.UseVisualStyleBackColor = true;
@@ -1107,9 +1135,10 @@
             // 
             // lblIconThicknessValue
             // 
+            this.lblIconThicknessValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblIconThicknessValue.AutoSize = true;
             this.lblIconThicknessValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblIconThicknessValue.Location = new System.Drawing.Point(308, 161);
+            this.lblIconThicknessValue.Location = new System.Drawing.Point(361, 161);
             this.lblIconThicknessValue.Name = "lblIconThicknessValue";
             this.lblIconThicknessValue.Size = new System.Drawing.Size(31, 13);
             this.lblIconThicknessValue.TabIndex = 24;
@@ -1118,9 +1147,10 @@
             // 
             // lblIconSizeValue
             // 
+            this.lblIconSizeValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblIconSizeValue.AutoSize = true;
             this.lblIconSizeValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblIconSizeValue.Location = new System.Drawing.Point(308, 111);
+            this.lblIconSizeValue.Location = new System.Drawing.Point(361, 111);
             this.lblIconSizeValue.Name = "lblIconSizeValue";
             this.lblIconSizeValue.Size = new System.Drawing.Size(31, 13);
             this.lblIconSizeValue.TabIndex = 23;
@@ -1139,13 +1169,14 @@
             // 
             // iconThickness
             // 
+            this.iconThickness.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.iconThickness.AutoSize = false;
             this.iconThickness.BackColor = System.Drawing.Color.White;
             this.iconThickness.LargeChange = 1;
             this.iconThickness.Location = new System.Drawing.Point(75, 159);
             this.iconThickness.Maximum = 20;
             this.iconThickness.Name = "iconThickness";
-            this.iconThickness.Size = new System.Drawing.Size(227, 27);
+            this.iconThickness.Size = new System.Drawing.Size(280, 27);
             this.iconThickness.TabIndex = 16;
             this.iconThickness.Value = 1;
             this.iconThickness.Scroll += new System.EventHandler(this.iconThickness_Scroll);
@@ -1163,13 +1194,14 @@
             // 
             // iconSize
             // 
+            this.iconSize.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.iconSize.AutoSize = false;
             this.iconSize.BackColor = System.Drawing.Color.White;
             this.iconSize.LargeChange = 1;
             this.iconSize.Location = new System.Drawing.Point(75, 109);
             this.iconSize.Maximum = 20;
             this.iconSize.Name = "iconSize";
-            this.iconSize.Size = new System.Drawing.Size(227, 27);
+            this.iconSize.Size = new System.Drawing.Size(280, 27);
             this.iconSize.TabIndex = 14;
             this.iconSize.Value = 1;
             this.iconSize.Scroll += new System.EventHandler(this.iconSize_Scroll);
@@ -1204,7 +1236,7 @@
             this.tabLabel.Location = new System.Drawing.Point(4, 22);
             this.tabLabel.Name = "tabLabel";
             this.tabLabel.Padding = new System.Windows.Forms.Padding(3);
-            this.tabLabel.Size = new System.Drawing.Size(345, 260);
+            this.tabLabel.Size = new System.Drawing.Size(398, 260);
             this.tabLabel.TabIndex = 1;
             this.tabLabel.Text = "Label";
             this.tabLabel.UseVisualStyleBackColor = true;
@@ -1282,7 +1314,7 @@
             this.tabLine.Controls.Add(this.btnLineColor);
             this.tabLine.Location = new System.Drawing.Point(4, 22);
             this.tabLine.Name = "tabLine";
-            this.tabLine.Size = new System.Drawing.Size(345, 260);
+            this.tabLine.Size = new System.Drawing.Size(398, 260);
             this.tabLine.TabIndex = 2;
             this.tabLine.Text = "Line";
             this.tabLine.UseVisualStyleBackColor = true;
@@ -1302,9 +1334,10 @@
             // 
             // lblLineThicknessSizeValue
             // 
+            this.lblLineThicknessSizeValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblLineThicknessSizeValue.AutoSize = true;
             this.lblLineThicknessSizeValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblLineThicknessSizeValue.Location = new System.Drawing.Point(299, 111);
+            this.lblLineThicknessSizeValue.Location = new System.Drawing.Point(352, 111);
             this.lblLineThicknessSizeValue.Name = "lblLineThicknessSizeValue";
             this.lblLineThicknessSizeValue.Size = new System.Drawing.Size(31, 13);
             this.lblLineThicknessSizeValue.TabIndex = 27;
@@ -1313,9 +1346,10 @@
             // 
             // lblLineArrowSizeValue
             // 
+            this.lblLineArrowSizeValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblLineArrowSizeValue.AutoSize = true;
             this.lblLineArrowSizeValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblLineArrowSizeValue.Location = new System.Drawing.Point(299, 61);
+            this.lblLineArrowSizeValue.Location = new System.Drawing.Point(352, 61);
             this.lblLineArrowSizeValue.Name = "lblLineArrowSizeValue";
             this.lblLineArrowSizeValue.Size = new System.Drawing.Size(31, 13);
             this.lblLineArrowSizeValue.TabIndex = 26;
@@ -1334,13 +1368,14 @@
             // 
             // lineThicknessSize
             // 
+            this.lineThicknessSize.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.lineThicknessSize.AutoSize = false;
             this.lineThicknessSize.BackColor = System.Drawing.Color.White;
             this.lineThicknessSize.LargeChange = 1;
             this.lineThicknessSize.Location = new System.Drawing.Point(73, 109);
             this.lineThicknessSize.Maximum = 30;
             this.lineThicknessSize.Name = "lineThicknessSize";
-            this.lineThicknessSize.Size = new System.Drawing.Size(220, 27);
+            this.lineThicknessSize.Size = new System.Drawing.Size(273, 27);
             this.lineThicknessSize.TabIndex = 22;
             this.lineThicknessSize.Value = 1;
             this.lineThicknessSize.Scroll += new System.EventHandler(this.lineThicknessSize_Scroll);
@@ -1358,13 +1393,14 @@
             // 
             // lineArrowSize
             // 
+            this.lineArrowSize.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.lineArrowSize.AutoSize = false;
             this.lineArrowSize.BackColor = System.Drawing.Color.White;
             this.lineArrowSize.LargeChange = 1;
             this.lineArrowSize.Location = new System.Drawing.Point(73, 59);
             this.lineArrowSize.Maximum = 20;
             this.lineArrowSize.Name = "lineArrowSize";
-            this.lineArrowSize.Size = new System.Drawing.Size(220, 27);
+            this.lineArrowSize.Size = new System.Drawing.Size(273, 27);
             this.lineArrowSize.TabIndex = 20;
             this.lineArrowSize.Value = 1;
             this.lineArrowSize.Scroll += new System.EventHandler(this.lineArrowSize_Scroll);
@@ -1393,11 +1429,12 @@
             // 
             // cboRenderOption
             // 
+            this.cboRenderOption.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.cboRenderOption.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboRenderOption.FormattingEnabled = true;
             this.cboRenderOption.Location = new System.Drawing.Point(118, 6);
             this.cboRenderOption.Name = "cboRenderOption";
-            this.cboRenderOption.Size = new System.Drawing.Size(231, 21);
+            this.cboRenderOption.Size = new System.Drawing.Size(284, 21);
             this.cboRenderOption.TabIndex = 0;
             this.cboRenderOption.SelectedIndexChanged += new System.EventHandler(this.cboRenderOption_SelectedIndexChanged);
             // 
@@ -1406,13 +1443,14 @@
             this.tabPage6.Controls.Add(this.groupBox6);
             this.tabPage6.Location = new System.Drawing.Point(4, 22);
             this.tabPage6.Name = "tabPage6";
-            this.tabPage6.Size = new System.Drawing.Size(359, 325);
+            this.tabPage6.Size = new System.Drawing.Size(412, 325);
             this.tabPage6.TabIndex = 5;
             this.tabPage6.Text = "Item Log";
             this.tabPage6.UseVisualStyleBackColor = true;
             // 
             // groupBox6
             // 
+            this.groupBox6.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox6.Controls.Add(this.chkItemLogVendorItems);
             this.groupBox6.Controls.Add(this.lblSoundVolumeValue);
             this.groupBox6.Controls.Add(this.lblItemDisplayForSecondsValue);
@@ -1436,7 +1474,7 @@
             this.groupBox6.Controls.Add(this.label21);
             this.groupBox6.Location = new System.Drawing.Point(11, 9);
             this.groupBox6.Name = "groupBox6";
-            this.groupBox6.Size = new System.Drawing.Size(335, 305);
+            this.groupBox6.Size = new System.Drawing.Size(388, 305);
             this.groupBox6.TabIndex = 0;
             this.groupBox6.TabStop = false;
             this.groupBox6.Text = "Item Log";
@@ -1454,9 +1492,10 @@
             // 
             // lblSoundVolumeValue
             // 
+            this.lblSoundVolumeValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblSoundVolumeValue.AutoSize = true;
             this.lblSoundVolumeValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblSoundVolumeValue.Location = new System.Drawing.Point(292, 187);
+            this.lblSoundVolumeValue.Location = new System.Drawing.Point(345, 187);
             this.lblSoundVolumeValue.Name = "lblSoundVolumeValue";
             this.lblSoundVolumeValue.Size = new System.Drawing.Size(25, 13);
             this.lblSoundVolumeValue.TabIndex = 29;
@@ -1465,9 +1504,10 @@
             // 
             // lblItemDisplayForSecondsValue
             // 
+            this.lblItemDisplayForSecondsValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblItemDisplayForSecondsValue.AutoSize = true;
             this.lblItemDisplayForSecondsValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblItemDisplayForSecondsValue.Location = new System.Drawing.Point(292, 228);
+            this.lblItemDisplayForSecondsValue.Location = new System.Drawing.Point(345, 228);
             this.lblItemDisplayForSecondsValue.Name = "lblItemDisplayForSecondsValue";
             this.lblItemDisplayForSecondsValue.Size = new System.Drawing.Size(33, 13);
             this.lblItemDisplayForSecondsValue.TabIndex = 25;
@@ -1500,6 +1540,7 @@
             // 
             // itemDisplayForSeconds
             // 
+            this.itemDisplayForSeconds.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.itemDisplayForSeconds.AutoSize = false;
             this.itemDisplayForSeconds.BackColor = System.Drawing.Color.White;
             this.itemDisplayForSeconds.LargeChange = 1;
@@ -1507,7 +1548,7 @@
             this.itemDisplayForSeconds.Maximum = 24;
             this.itemDisplayForSeconds.Minimum = 1;
             this.itemDisplayForSeconds.Name = "itemDisplayForSeconds";
-            this.itemDisplayForSeconds.Size = new System.Drawing.Size(201, 27);
+            this.itemDisplayForSeconds.Size = new System.Drawing.Size(254, 27);
             this.itemDisplayForSeconds.SmallChange = 25;
             this.itemDisplayForSeconds.TabIndex = 11;
             this.itemDisplayForSeconds.Value = 1;
@@ -1556,6 +1597,7 @@
             // 
             // soundVolume
             // 
+            this.soundVolume.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.soundVolume.AutoSize = false;
             this.soundVolume.BackColor = System.Drawing.Color.White;
             this.soundVolume.Cursor = System.Windows.Forms.Cursors.Default;
@@ -1563,7 +1605,7 @@
             this.soundVolume.Location = new System.Drawing.Point(85, 187);
             this.soundVolume.Maximum = 20;
             this.soundVolume.Name = "soundVolume";
-            this.soundVolume.Size = new System.Drawing.Size(201, 27);
+            this.soundVolume.Size = new System.Drawing.Size(254, 27);
             this.soundVolume.SmallChange = 25;
             this.soundVolume.TabIndex = 28;
             this.soundVolume.Scroll += new System.EventHandler(this.soundVolume_Scroll);
@@ -1609,28 +1651,31 @@
             // 
             // txtSoundFile
             // 
+            this.txtSoundFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSoundFile.Location = new System.Drawing.Point(85, 147);
             this.txtSoundFile.Name = "txtSoundFile";
-            this.txtSoundFile.Size = new System.Drawing.Size(240, 20);
+            this.txtSoundFile.Size = new System.Drawing.Size(293, 20);
             this.txtSoundFile.TabIndex = 5;
             this.txtSoundFile.TextChanged += new System.EventHandler(this.txtSoundFile_TextChanged);
             this.txtSoundFile.LostFocus += new System.EventHandler(this.txtSoundFile_LostFocus);
             // 
             // cboItemLogPosition
             // 
+            this.cboItemLogPosition.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.cboItemLogPosition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboItemLogPosition.FormattingEnabled = true;
             this.cboItemLogPosition.Location = new System.Drawing.Point(238, 17);
             this.cboItemLogPosition.Name = "cboItemLogPosition";
-            this.cboItemLogPosition.Size = new System.Drawing.Size(87, 21);
+            this.cboItemLogPosition.Size = new System.Drawing.Size(140, 21);
             this.cboItemLogPosition.TabIndex = 38;
             this.cboItemLogPosition.SelectedIndexChanged += new System.EventHandler(this.cboItemLogPosition_SelectedIndexChanged);
             // 
             // txtFilterFile
             // 
+            this.txtFilterFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.txtFilterFile.Location = new System.Drawing.Point(85, 88);
             this.txtFilterFile.Name = "txtFilterFile";
-            this.txtFilterFile.Size = new System.Drawing.Size(240, 20);
+            this.txtFilterFile.Size = new System.Drawing.Size(293, 20);
             this.txtFilterFile.TabIndex = 2;
             this.txtFilterFile.TextChanged += new System.EventHandler(this.txtFilterFile_TextChanged);
             // 
@@ -1673,13 +1718,14 @@
             this.tabPage7.Location = new System.Drawing.Point(4, 22);
             this.tabPage7.Name = "tabPage7";
             this.tabPage7.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage7.Size = new System.Drawing.Size(359, 325);
+            this.tabPage7.Size = new System.Drawing.Size(412, 325);
             this.tabPage7.TabIndex = 6;
             this.tabPage7.Text = "Hotkeys";
             this.tabPage7.UseVisualStyleBackColor = true;
             // 
             // grpHotkeys
             // 
+            this.grpHotkeys.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.grpHotkeys.Controls.Add(this.txtHideMapKey);
             this.grpHotkeys.Controls.Add(this.lblHideMapKey);
             this.grpHotkeys.Controls.Add(this.txtZoomOutKey);
@@ -1694,7 +1740,7 @@
             this.grpHotkeys.Controls.Add(this.label22);
             this.grpHotkeys.Location = new System.Drawing.Point(11, 9);
             this.grpHotkeys.Name = "grpHotkeys";
-            this.grpHotkeys.Size = new System.Drawing.Size(335, 214);
+            this.grpHotkeys.Size = new System.Drawing.Size(388, 214);
             this.grpHotkeys.TabIndex = 9;
             this.grpHotkeys.TabStop = false;
             this.grpHotkeys.Text = "Hotkeys";
@@ -1820,26 +1866,28 @@
             this.tabPage4.Controls.Add(this.groupBox8);
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
-            this.tabPage4.Size = new System.Drawing.Size(359, 325);
+            this.tabPage4.Size = new System.Drawing.Size(412, 325);
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "Advanced";
             this.tabPage4.UseVisualStyleBackColor = true;
             // 
             // groupBox2
             // 
+            this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox2.Controls.Add(this.btnRemoveHidden);
             this.groupBox2.Controls.Add(this.btnAddHidden);
             this.groupBox2.Controls.Add(this.lstHidden);
             this.groupBox2.Location = new System.Drawing.Point(11, 9);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(335, 100);
+            this.groupBox2.Size = new System.Drawing.Size(388, 100);
             this.groupBox2.TabIndex = 2;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Hidden Areas";
             // 
             // btnRemoveHidden
             // 
-            this.btnRemoveHidden.Location = new System.Drawing.Point(309, 48);
+            this.btnRemoveHidden.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnRemoveHidden.Location = new System.Drawing.Point(362, 48);
             this.btnRemoveHidden.Name = "btnRemoveHidden";
             this.btnRemoveHidden.Size = new System.Drawing.Size(20, 23);
             this.btnRemoveHidden.TabIndex = 2;
@@ -1849,7 +1897,8 @@
             // 
             // btnAddHidden
             // 
-            this.btnAddHidden.Location = new System.Drawing.Point(309, 19);
+            this.btnAddHidden.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnAddHidden.Location = new System.Drawing.Point(362, 19);
             this.btnAddHidden.Name = "btnAddHidden";
             this.btnAddHidden.Size = new System.Drawing.Size(20, 23);
             this.btnAddHidden.TabIndex = 1;
@@ -1859,28 +1908,39 @@
             // 
             // lstHidden
             // 
+            this.lstHidden.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.lstHidden.FormattingEnabled = true;
             this.lstHidden.Location = new System.Drawing.Point(10, 19);
             this.lstHidden.Name = "lstHidden";
-            this.lstHidden.Size = new System.Drawing.Size(293, 69);
+            this.lstHidden.Size = new System.Drawing.Size(346, 69);
             this.lstHidden.TabIndex = 0;
             // 
             // groupBoxAuthorizedWindowTitle
             // 
+            this.groupBoxAuthorizedWindowTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxAuthorizedWindowTitle.Controls.Add(this.txtAuthorizedWindowTitle);
             this.groupBoxAuthorizedWindowTitle.Controls.Add(this.btnRemoveAuthorizedWindowTitle);
             this.groupBoxAuthorizedWindowTitle.Controls.Add(this.btnAddAuthorizedWindowTitle);
             this.groupBoxAuthorizedWindowTitle.Controls.Add(this.lstAuthorizedWindowTitle);
             this.groupBoxAuthorizedWindowTitle.Location = new System.Drawing.Point(11, 115);
             this.groupBoxAuthorizedWindowTitle.Name = "groupBoxAuthorizedWindowTitle";
-            this.groupBoxAuthorizedWindowTitle.Size = new System.Drawing.Size(335, 124);
+            this.groupBoxAuthorizedWindowTitle.Size = new System.Drawing.Size(388, 124);
             this.groupBoxAuthorizedWindowTitle.TabIndex = 2;
             this.groupBoxAuthorizedWindowTitle.TabStop = false;
             this.groupBoxAuthorizedWindowTitle.Text = "Authorized Window Titles";
             // 
+            // txtAuthorizedWindowTitle
+            // 
+            this.txtAuthorizedWindowTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtAuthorizedWindowTitle.Location = new System.Drawing.Point(10, 94);
+            this.txtAuthorizedWindowTitle.Name = "txtAuthorizedWindowTitle";
+            this.txtAuthorizedWindowTitle.Size = new System.Drawing.Size(346, 20);
+            this.txtAuthorizedWindowTitle.TabIndex = 3;
+            // 
             // btnRemoveAuthorizedWindowTitle
             // 
-            this.btnRemoveAuthorizedWindowTitle.Location = new System.Drawing.Point(309, 44);
+            this.btnRemoveAuthorizedWindowTitle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnRemoveAuthorizedWindowTitle.Location = new System.Drawing.Point(362, 44);
             this.btnRemoveAuthorizedWindowTitle.Name = "btnRemoveAuthorizedWindowTitle";
             this.btnRemoveAuthorizedWindowTitle.Size = new System.Drawing.Size(20, 23);
             this.btnRemoveAuthorizedWindowTitle.TabIndex = 2;
@@ -1890,7 +1950,8 @@
             // 
             // btnAddAuthorizedWindowTitle
             // 
-            this.btnAddAuthorizedWindowTitle.Location = new System.Drawing.Point(309, 92);
+            this.btnAddAuthorizedWindowTitle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnAddAuthorizedWindowTitle.Location = new System.Drawing.Point(362, 92);
             this.btnAddAuthorizedWindowTitle.Name = "btnAddAuthorizedWindowTitle";
             this.btnAddAuthorizedWindowTitle.Size = new System.Drawing.Size(20, 23);
             this.btnAddAuthorizedWindowTitle.TabIndex = 1;
@@ -1900,20 +1961,22 @@
             // 
             // lstAuthorizedWindowTitle
             // 
+            this.lstAuthorizedWindowTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.lstAuthorizedWindowTitle.FormattingEnabled = true;
             this.lstAuthorizedWindowTitle.Location = new System.Drawing.Point(10, 19);
             this.lstAuthorizedWindowTitle.Name = "lstAuthorizedWindowTitle";
-            this.lstAuthorizedWindowTitle.Size = new System.Drawing.Size(293, 69);
+            this.lstAuthorizedWindowTitle.Size = new System.Drawing.Size(346, 69);
             this.lstAuthorizedWindowTitle.TabIndex = 0;
             // 
             // groupBox8
             // 
+            this.groupBox8.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox8.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.groupBox8.Controls.Add(this.label3);
             this.groupBox8.Controls.Add(this.chkDPIAware);
             this.groupBox8.Location = new System.Drawing.Point(11, 245);
             this.groupBox8.Name = "groupBox8";
-            this.groupBox8.Size = new System.Drawing.Size(335, 58);
+            this.groupBox8.Size = new System.Drawing.Size(388, 58);
             this.groupBox8.TabIndex = 29;
             this.groupBox8.TabStop = false;
             this.groupBox8.Text = "High DPI";
@@ -1940,18 +2003,11 @@
             this.chkDPIAware.UseVisualStyleBackColor = true;
             this.chkDPIAware.CheckedChanged += new System.EventHandler(this.chkDPIAware_CheckedChanged);
             // 
-            // txtAuthorizedWindowTitle
-            // 
-            this.txtAuthorizedWindowTitle.Location = new System.Drawing.Point(10, 94);
-            this.txtAuthorizedWindowTitle.Name = "txtAuthorizedWindowTitle";
-            this.txtAuthorizedWindowTitle.Size = new System.Drawing.Size(293, 20);
-            this.txtAuthorizedWindowTitle.TabIndex = 3;
-            // 
             // ConfigEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(389, 374);
+            this.ClientSize = new System.Drawing.Size(442, 374);
             this.Controls.Add(this.tabControl1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -2011,7 +2067,6 @@
             this.groupBox8.ResumeLayout(false);
             this.groupBox8.PerformLayout();
             this.ResumeLayout(false);
-
         }
 
         #endregion

--- a/Helpers/GameManager.cs
+++ b/Helpers/GameManager.cs
@@ -177,7 +177,7 @@ namespace MapAssist.Helpers
             {
                 if (_UnitHashTableOffset == IntPtr.Zero)
                 {
-                    _UnitHashTableOffset = processContext.GetUnitHashtableOffset();
+                    PopulateMissingOffsets();
                 }
 
                 return processContext.Read<UnitHashTable>(IntPtr.Add(_UnitHashTableOffset, offset));
@@ -193,10 +193,7 @@ namespace MapAssist.Helpers
                     return _ExpansionCheckOffset;
                 }
 
-                using (var processContext = GetProcessContext())
-                {
-                    _ExpansionCheckOffset = processContext.GetExpansionOffset();
-                }
+                PopulateMissingOffsets();
 
                 return _ExpansionCheckOffset;
             }
@@ -211,10 +208,7 @@ namespace MapAssist.Helpers
                     return _GameNameOffset;
                 }
 
-                using (var processContext = GetProcessContext())
-                {
-                    _GameNameOffset = (IntPtr)processContext.GetGameNameOffset();
-                }
+                PopulateMissingOffsets();
 
                 return _GameNameOffset;
             }
@@ -229,10 +223,7 @@ namespace MapAssist.Helpers
                     return _MenuPanelOpenOffset;
                 }
 
-                using (var processContext = GetProcessContext())
-                {
-                    _MenuPanelOpenOffset = (IntPtr)processContext.GetMenuOpenOffset();
-                }
+                PopulateMissingOffsets();
 
                 return _MenuPanelOpenOffset;
             }
@@ -247,10 +238,7 @@ namespace MapAssist.Helpers
                     return _MenuDataOffset;
                 }
 
-                using (var processContext = GetProcessContext())
-                {
-                    _MenuDataOffset = (IntPtr)processContext.GetMenuDataOffset();
-                }
+                PopulateMissingOffsets();
 
                 return _MenuDataOffset;
             }
@@ -265,10 +253,7 @@ namespace MapAssist.Helpers
                     return _MapSeedOffset;
                 }
 
-                using (var processContext = GetProcessContext())
-                {
-                    _MapSeedOffset = (IntPtr)processContext.GetMapSeedOffset();
-                }
+                PopulateMissingOffsets();
 
                 return _MapSeedOffset;
             }
@@ -283,10 +268,7 @@ namespace MapAssist.Helpers
                     return _RosterDataOffset;
                 }
 
-                using (var processContext = GetProcessContext())
-                {
-                    _RosterDataOffset = processContext.GetRosterDataOffset();
-                }
+                PopulateMissingOffsets();
 
                 return _RosterDataOffset;
             }
@@ -301,10 +283,7 @@ namespace MapAssist.Helpers
                     return _LastHoverDataOffset;
                 }
 
-                using (var processContext = GetProcessContext())
-                {
-                    _LastHoverDataOffset = processContext.GetLastHoverObjectOffset();
-                }
+                PopulateMissingOffsets();
 
                 return _LastHoverDataOffset;
             }
@@ -319,14 +298,76 @@ namespace MapAssist.Helpers
                     return _InteractedNpcOffset;
                 }
 
-                using (var processContext = GetProcessContext())
-                {
-                    _InteractedNpcOffset = processContext.GetInteractedNpcOffset();
-                }
+                PopulateMissingOffsets();
 
                 return _InteractedNpcOffset;
             }
         }
+
+        private static void PopulateMissingOffsets()
+        {
+            // The fact we are here means we are missing some offset, 
+            // which means we will need the buffer.
+            using (var processContext = GetProcessContext())
+            {
+                var buffer = processContext.Read<byte>(processContext.BaseAddr, processContext.ModuleSize);
+
+                if (_UnitHashTableOffset == IntPtr.Zero)
+                {
+                    _UnitHashTableOffset = processContext.GetUnitHashtableOffset(buffer);
+                    _log.Info($"Found offset {nameof(_UnitHashTableOffset)} {_UnitHashTableOffset.ToInt64()-processContext.BaseAddr.ToInt64():X}");
+                }
+
+                if (_ExpansionCheckOffset == IntPtr.Zero)
+                {
+                    _ExpansionCheckOffset = processContext.GetExpansionOffset(buffer);
+                    _log.Info($"Found offset {nameof(_ExpansionCheckOffset)} {_ExpansionCheckOffset.ToInt64()-processContext.BaseAddr.ToInt64():X}");
+                }
+
+                if (_GameNameOffset == IntPtr.Zero)
+                {
+                    _GameNameOffset = processContext.GetGameNameOffset(buffer);
+                    _log.Info($"Found offset {nameof(_GameNameOffset)} {_GameNameOffset.ToInt64()-processContext.BaseAddr.ToInt64():X}");
+                }
+
+                if (_MenuPanelOpenOffset == IntPtr.Zero)
+                {
+                    _MenuPanelOpenOffset = processContext.GetMenuOpenOffset(buffer);
+                    _log.Info($"Found offset {nameof(_MenuPanelOpenOffset)} {_MenuPanelOpenOffset.ToInt64()-processContext.BaseAddr.ToInt64():X}");
+                }
+
+                if (_MenuDataOffset == IntPtr.Zero)
+                {
+                    _MenuDataOffset = processContext.GetMenuDataOffset(buffer);
+                    _log.Info($"Found offset {nameof(_MenuDataOffset)} {_MenuDataOffset.ToInt64()-processContext.BaseAddr.ToInt64():X}");
+                }
+
+                if (_MapSeedOffset == IntPtr.Zero)
+                {
+                    _MapSeedOffset = processContext.GetMapSeedOffset(buffer);
+                    _log.Info($"Found offset {nameof(_MapSeedOffset)} {_MapSeedOffset.ToInt64()-processContext.BaseAddr.ToInt64():X}");
+                }
+
+                if (_RosterDataOffset == IntPtr.Zero)
+                {
+                    _RosterDataOffset = processContext.GetRosterDataOffset(buffer);
+                    _log.Info($"Found offset {nameof(_RosterDataOffset)} {_RosterDataOffset.ToInt64()-processContext.BaseAddr.ToInt64():X}");
+                }
+
+                if (_LastHoverDataOffset == IntPtr.Zero)
+                {
+                    _LastHoverDataOffset = processContext.GetLastHoverObjectOffset(buffer);
+                    _log.Info($"Found offset {nameof(_LastHoverDataOffset)} {_LastHoverDataOffset.ToInt64()-processContext.BaseAddr.ToInt64():X}");
+                }
+
+                if (_InteractedNpcOffset == IntPtr.Zero)
+                {
+                    _InteractedNpcOffset = processContext.GetInteractedNpcOffset(buffer);
+                    _log.Info($"Found offset {nameof(_InteractedNpcOffset)} {_InteractedNpcOffset.ToInt64()-processContext.BaseAddr.ToInt64():X}");
+                }
+            }
+        }
+
 
         public static void Dispose()
         {

--- a/Helpers/Pattern.cs
+++ b/Helpers/Pattern.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace MapAssist.Helpers
+{
+    public class Pattern
+    {
+        private readonly string _mask;
+        private readonly byte[] _pattern;
+
+        public Pattern(string pattern, string mask = null)
+        {
+            List<string> cleanPattern = pattern
+                .Replace("\\x", " ")
+                .Replace("??", "?")
+                .Trim()
+                .Split(' ')
+                .ToList();
+
+            mask = string.Join("", cleanPattern.Select(o => o == "?" ? "?" : "x"));
+            cleanPattern = cleanPattern.Select(o => o == "?" ? "00" : o).ToList();
+
+            _pattern = cleanPattern
+                .Select(o => byte.Parse(o, NumberStyles.HexNumber))
+                .ToArray();
+            _mask = mask;
+        }
+
+        public bool Match(byte[] data, int offset)
+        {
+            if (offset + _pattern.Length >= data.Length) return false;
+
+            for (var i = 0; i < _pattern.Length; i++)
+            {
+                if (_mask[i] == '?') continue;
+
+                if (data[offset + i] != _pattern[i]) return false;
+            }
+
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return "Pattern: " + string.Join(
+                " ", _mask.Select((c, i) => c == '?' ? "?" : _pattern[i].ToString("X"))
+            );
+        }
+    }
+}

--- a/Helpers/Pattern.cs
+++ b/Helpers/Pattern.cs
@@ -9,7 +9,7 @@ namespace MapAssist.Helpers
         private readonly string _mask;
         private readonly byte[] _pattern;
 
-        public Pattern(string pattern, string mask = null)
+        public Pattern(string pattern)
         {
             List<string> cleanPattern = pattern
                 .Replace("\\x", " ")

--- a/Helpers/Pattern.cs
+++ b/Helpers/Pattern.cs
@@ -18,13 +18,12 @@ namespace MapAssist.Helpers
                 .Split(' ')
                 .ToList();
 
-            mask = string.Join("", cleanPattern.Select(o => o == "?" ? "?" : "x"));
+            _mask = string.Join("", cleanPattern.Select(o => o == "?" ? "?" : "x"));
             cleanPattern = cleanPattern.Select(o => o == "?" ? "00" : o).ToList();
 
             _pattern = cleanPattern
                 .Select(o => byte.Parse(o, NumberStyles.HexNumber))
-                .ToArray();
-            _mask = mask;
+                .ToArray();            
         }
 
         public bool Match(byte[] data, int offset)

--- a/Helpers/ProcessContext.cs
+++ b/Helpers/ProcessContext.cs
@@ -20,7 +20,6 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace MapAssist.Helpers
 {
@@ -44,19 +43,19 @@ namespace MapAssist.Helpers
 
         public IntPtr Handle { get => _handle; }
         public IntPtr BaseAddr { get => _baseAddr; }
+        public int ModuleSize { get => _moduleSize; }
         public int ProcessId { get => _process.Id; }
 
-        public IntPtr GetUnitHashtableOffset()
+        public IntPtr GetUnitHashtableOffset(byte[] buffer)
         {
-            var pattern = "\x48\x8D\x0D\x00\x00\x00\x00\x48\xC1\xE0\x0A\x48\x03\xC1\xC3\xCC";
-            var mask = "xxx????xxxxxxxxx";
-            var patternAddress = FindPattern(pattern, mask);
+            var pattern = new Pattern("48 8D 0D ? ? ? ? 48 C1 E0 0A 48 03 C1 C3 CC");
+            var patternAddress = FindPattern(buffer, pattern);
 
             var offsetBuffer = new byte[4];
             var resultRelativeAddress = IntPtr.Add(patternAddress, 3);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                _log.Info($"Failed to find pattern {PatternToString(pattern)}");
+                _log.Info($"Failed to find pattern {pattern}");
                 return IntPtr.Zero;
             }
 
@@ -65,17 +64,15 @@ namespace MapAssist.Helpers
             return IntPtr.Add(_baseAddr, (int)(delta + 7 + offsetAddressToInt));
         }
 
-        public IntPtr GetExpansionOffset()
+        public IntPtr GetExpansionOffset(byte[] buffer)
         {
-            var pattern = "\x48\x8B\x05\x00\x00\x00\x00\x48\x8B\xD9\xF3\x0F\x10\x50\x00";
-            var mask = "xxx????xxxxxxx?";
-            var patternAddress = FindPattern(pattern, mask);
-
+            var pattern = new Pattern("48 8B 05 ? ? ? ? 48 8B D9 F3 0F 10 50");
+            var patternAddress = FindPattern(buffer, pattern);
             var offsetBuffer = new byte[4];
             var resultRelativeAddress = IntPtr.Add(patternAddress, 3);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                _log.Info($"Failed to find pattern {PatternToString(pattern)}");
+                _log.Info($"Failed to find pattern {pattern}");
                 return IntPtr.Zero;
             }
 
@@ -84,17 +81,16 @@ namespace MapAssist.Helpers
             return IntPtr.Add(_baseAddr, (int)(delta + 7 + offsetAddressToInt));
         }
 
-        public IntPtr GetGameNameOffset()
+        public IntPtr GetGameNameOffset(byte[] buffer)
         {
-            var pattern = "\x44\x88\x25\x00\x00\x00\x00\x66\x44\x89\x25\x00\x00\x00\x00";
-            var mask = "xxx????xxxx????";
-            var patternAddress = FindPattern(pattern, mask);
+            var pattern = new Pattern("44 88 25 ? ? ? ? 66 44 89 25");
+            var patternAddress = FindPattern(buffer, pattern);
 
             var offsetBuffer = new byte[4];
             var resultRelativeAddress = IntPtr.Add(patternAddress, 3);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                _log.Info($"Failed to find pattern {PatternToString(pattern)}");
+                _log.Info($"Failed to find pattern {pattern}");
                 return IntPtr.Zero;
             }
 
@@ -103,17 +99,16 @@ namespace MapAssist.Helpers
             return IntPtr.Add(_baseAddr, (int)(delta - 0x121 + offsetAddressToInt));
         }
 
-        public IntPtr GetMenuOpenOffset()
+        public IntPtr GetMenuOpenOffset(byte[] buffer)
         {
-            var pattern = "\x8B\x05\x00\x00\x00\x00\x89\x44\x24\x20\x74\x07";
-            var mask = "xx????xxxxxx";
-            var patternAddress = FindPattern(pattern, mask);
+            var pattern = new Pattern("8B 05 ? ? ? ? 89 44 24 20 74 07");
+            var patternAddress = FindPattern(buffer, pattern);
 
             var offsetBuffer = new byte[4];
             var resultRelativeAddress = IntPtr.Add(patternAddress, 2);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                _log.Info($"Failed to find pattern {PatternToString(pattern)}");
+                _log.Info($"Failed to find pattern {pattern}");
                 return IntPtr.Zero;
             }
 
@@ -122,17 +117,16 @@ namespace MapAssist.Helpers
             return IntPtr.Add(_baseAddr, (int)(delta + 6 + offsetAddressToInt));
         }
 
-        public IntPtr GetMenuDataOffset()
+        public IntPtr GetMenuDataOffset(byte[] buffer)
         {
-            var pattern = "\x45\x8B\xD7\x4C\x8D\x05\x00\x00\x00\x00";
-            var mask = "xxxxxx????";
-            var patternAddress = FindPattern(pattern, mask);
+            var pattern = new Pattern("45 8B D7 4C 8D 05 ? ? ? ?");
+            var patternAddress = FindPattern(buffer, pattern);
 
             var offsetBuffer = new byte[4];
             var resultRelativeAddress = IntPtr.Add(patternAddress, 6);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                _log.Info($"Failed to find pattern {PatternToString(pattern)}");
+                _log.Info($"Failed to find pattern {pattern}");
                 return IntPtr.Zero;
             }
 
@@ -141,17 +135,16 @@ namespace MapAssist.Helpers
             return IntPtr.Add(_baseAddr, (int)(delta + 10 + offsetAddressToInt));
         }
 
-        public IntPtr GetMapSeedOffset()
+        public IntPtr GetMapSeedOffset(byte[] buffer)
         {
-            var pattern = "\x41\x8B\xF9\x48\x8D\x0D\x00\x00\x00\x00";
-            var mask = "xxxxxx????";
-            var patternAddress = FindPattern(pattern, mask);
+            var pattern = new Pattern("41 8B F9 48 8D 0D ? ? ? ?");
+            var patternAddress = FindPattern(buffer, pattern);
 
             var offsetBuffer = new byte[4];
             var resultRelativeAddress = IntPtr.Add(patternAddress, 6);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                _log.Info($"Failed to find pattern {PatternToString(pattern)}");
+                _log.Info($"Failed to find pattern {pattern}");
                 return IntPtr.Zero;
             }
 
@@ -160,17 +153,16 @@ namespace MapAssist.Helpers
             return IntPtr.Add(_baseAddr, (int)(delta + 0xEA + offsetAddressToInt));
         }
 
-        public IntPtr GetRosterDataOffset()
+        public IntPtr GetRosterDataOffset(byte[] buffer)
         {
-            var pattern = "\x02\x45\x33\xD2\x4D\x8B";
-            var mask = "xxxxxx";
-            var patternAddress = FindPattern(pattern, mask);
+            var pattern = new Pattern("02 45 33 D2 4D 8B");
+            var patternAddress = FindPattern(buffer, pattern);
 
             var offsetBuffer = new byte[4];
             var resultRelativeAddress = IntPtr.Add(patternAddress, -3);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                _log.Info($"Failed to find pattern {PatternToString(pattern)}");
+                _log.Info($"Failed to find pattern {pattern}");
                 return IntPtr.Zero;
             }
             var offsetAddressToInt = BitConverter.ToInt32(offsetBuffer, 0);
@@ -178,50 +170,36 @@ namespace MapAssist.Helpers
             return IntPtr.Add(_baseAddr, (int)(delta + 1 + offsetAddressToInt));
         }
 
-        public IntPtr GetInteractedNpcOffset()
+        public IntPtr GetInteractedNpcOffset(byte[] buffer)
         {
-            var pattern = "\x43\x01\x84\x31\x00\x00\x00\x00";
-            var mask = "xxxx????";
-            var patternAddress = FindPattern(pattern, mask);
+            var pattern = new Pattern("43 01 84 31 ? ? ? ?");
+            var patternAddress = FindPattern(buffer, pattern);
 
             var offsetBuffer = new byte[4];
             var resultRelativeAddress = IntPtr.Add(patternAddress, 4);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                _log.Info($"Failed to find pattern {PatternToString(pattern)}");
+                _log.Info($"Failed to find pattern {pattern}");
                 return IntPtr.Zero;
             }
             var offsetAddressToInt = BitConverter.ToInt32(offsetBuffer, 0);
             return IntPtr.Add(_baseAddr, (int)(offsetAddressToInt + 0x1D4));
         }
 
-        public IntPtr GetLastHoverObjectOffset()
+        public IntPtr GetLastHoverObjectOffset(byte[] buffer)
         {
-            var pattern = "\xC6\x84\xC2\x00\x00\x00\x00\x00\x48\x8B\x74\x24\x00";
-            var mask = "xxx?????xxxx?";
-            IntPtr patternAddress = FindPattern(pattern, mask);
+            var pattern = new Pattern("C6 84 C2 ? ? ? ? ? 48 8B 74 24");
+            IntPtr patternAddress = FindPattern(buffer, pattern);
 
             var offsetBuffer = new byte[4];
             var resultRelativeAddress = IntPtr.Add(patternAddress, 3);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
-                _log.Info($"Failed to find pattern {PatternToString(pattern)}");
+                _log.Info($"Failed to find pattern {pattern}");
                 return IntPtr.Zero;
             }
             var offsetAddressToInt = BitConverter.ToInt32(offsetBuffer, 0) - 1;
             return IntPtr.Add(_baseAddr, offsetAddressToInt);
-        }
-
-        public byte[] GetProcessMemory()
-        {
-            var memoryBuffer = new byte[_moduleSize];
-            if (WindowsExternal.ReadProcessMemory(_handle, _baseAddr, memoryBuffer, _moduleSize, out _) == false)
-            {
-                _log.Info("We failed to read the process memory");
-                return null;
-            }
-
-            return memoryBuffer;
         }
 
         public T[] Read<T>(IntPtr address, int count) where T : struct
@@ -248,33 +226,17 @@ namespace MapAssist.Helpers
 
         public T Read<T>(IntPtr address) where T : struct => Read<T>(address, 1)[0];
 
-        public IntPtr FindPattern(string pattern, string mask)
+        public IntPtr FindPattern(byte[] buffer, Pattern pattern)
         {
-            var buffer = GetProcessMemory();
-
-            var patternLength = pattern.Length;
-            for (var i = 0; i < _moduleSize - patternLength; i++)
+            for (var i = 0; i < buffer.Length; i++)
             {
-                var found = true;
-                for (var j = 0; j < patternLength; j++)
-                {
-                    if (mask[j] != '?' && pattern[j] != buffer[i + j])
-                    {
-                        found = false;
-                        break;
-                    }
-                }
-
-                if (found)
+                if (pattern.Match(buffer, i))
                 {
                     return IntPtr.Add(_baseAddr, i);
                 }
             }
-
             return IntPtr.Zero;
         }
-
-        public string PatternToString(string pattern) => "\\x" + BitConverter.ToString(Encoding.Default.GetBytes(pattern)).Replace("-", "\\x");
 
         protected virtual void Dispose(bool disposing)
         {

--- a/Helpers/ProcessContext.cs
+++ b/Helpers/ProcessContext.cs
@@ -211,6 +211,14 @@ namespace MapAssist.Helpers
             {
                 WindowsExternal.ReadProcessMemory(_handle, address, buf, buf.Length, out _);
                 var result = new T[count];
+
+                // Optimisation when reading byte sized things.
+                if (sz == 1)
+                {
+                    Buffer.BlockCopy(buf, 0, result, 0, buf.Length);
+                    return result;
+                }
+
                 for (var i = 0; i < count; i++)
                 {
                     result[i] = (T)Marshal.PtrToStructure(handle.AddrOfPinnedObject() + (i * sz), typeof(T));

--- a/MapAssist.csproj
+++ b/MapAssist.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Helpers\ItemExport.cs" />
     <Compile Include="Helpers\Localization.cs" />
     <Compile Include="Helpers\LootFilter.cs" />
+    <Compile Include="Helpers\Pattern.cs" />
     <Compile Include="Helpers\ProcessContext.cs" />
     <Compile Include="Helpers\YamlConverters.cs" />
     <Compile Include="Interfaces\IUpdatable.cs" />


### PR DESCRIPTION
1. Properly anchor UI elements so that they resize when you resize the dialog.
2. Simplify specifying patterns
3. Scan for all patterns in one go, only having to copy the memory once.