### PR TITLE
Add overlay hiding support for any menu layout

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -912,7 +912,8 @@ namespace MapAssist.Helpers
                     DrawGraphicsEventArgs e, bool errorLoadingAreaData)
         {
             var isTopLeft = MapAssistConfiguration.Loaded.GameInfo.Position == GameInfoPosition.TopLeft;
-            if ((_gameData.MenuPanelOpen & (isTopLeft ? 0x2 : 0x1)) > 0)
+            var overlapPanelState = isTopLeft ? MenuPanelState.LeftOpen : MenuPanelState.RightOpen;
+            if (_gameData.MenuPanelOpen == MenuPanelState.BothOpen || _gameData.MenuPanelOpen == overlapPanelState)
             {
                 return anchor;
             }
@@ -1007,7 +1008,8 @@ namespace MapAssist.Helpers
         public void DrawItemLog(Graphics gfx, Point anchor)
         {
             var isTopLeft = MapAssistConfiguration.Loaded.ItemLog.Position == GameInfoPosition.TopLeft;
-            if ((_gameData.MenuPanelOpen & (isTopLeft ? 0x2 : 0x1)) > 0)
+            var overlapPanelState = isTopLeft ? MenuPanelState.LeftOpen : MenuPanelState.RightOpen;
+            if (_gameData.MenuPanelOpen == MenuPanelState.BothOpen || _gameData.MenuPanelOpen == overlapPanelState)
             {
                 return;
             }

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -41,7 +41,7 @@ namespace MapAssist.Helpers
             {
                 _currentProcessId = processContext.ProcessId;
 
-                var menuOpen = processContext.Read<byte>(GameManager.MenuOpenOffset);
+                var menuPanelOpened = (MenuPanelState)processContext.Read<byte>(GameManager.MenuOpenOffset);
                 var menuData = processContext.Read<Structs.MenuData>(GameManager.MenuDataOffset);
                 var lastHoverData = processContext.Read<Structs.HoverData>(GameManager.LastHoverDataOffset);
                 var lastNpcInteracted = (Npc)processContext.Read<ushort>(GameManager.InteractedNpcOffset);
@@ -383,7 +383,7 @@ namespace MapAssist.Helpers
                     Session = _sessions[_currentProcessId],
                     Roster = rosterData,
                     MenuOpen = menuData,
-                    MenuPanelOpen = menuOpen,
+                    MenuPanelOpen = menuPanelOpened,
                     LastNpcInteracted = lastNpcInteracted,
                     ProcessId = _currentProcessId
                 };

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -2,6 +2,7 @@
 using GameOverlay.Windows;
 using MapAssist.Helpers;
 using MapAssist.Settings;
+using MapAssist.Structs;
 using MapAssist.Types;
 using System;
 using System.Windows.Forms;
@@ -69,8 +70,7 @@ namespace MapAssist
                             var overlayHidden = !_show ||
                                 errorLoadingAreaData ||
                                 (MapAssistConfiguration.Loaded.RenderingConfiguration.ToggleViaInGameMap && !_gameData.MenuOpen.Map) ||
-                                (MapAssistConfiguration.Loaded.RenderingConfiguration.ToggleViaInGamePanels && _gameData.MenuPanelOpen > 0) ||
-                                (MapAssistConfiguration.Loaded.RenderingConfiguration.ToggleViaInGamePanels && _gameData.MenuOpen.EscMenu) ||
+                                (MapAssistConfiguration.Loaded.RenderingConfiguration.ToggleViaInGamePanels && _gameData.MenuOpen.IsAnyMenuOpen()) ||
                                 Array.Exists(MapAssistConfiguration.Loaded.HiddenAreas, area => area == _gameData.Area) ||
                                 _gameData.Area == Area.None ||
                                 gfx.Width == 1 ||

--- a/Structs/Menus.cs
+++ b/Structs/Menus.cs
@@ -33,7 +33,9 @@ namespace MapAssist.Structs
         [FieldOffset(0x0D)] public bool Anvil; // Imbue and sockets
         [MarshalAs(UnmanagedType.U1)]
         [FieldOffset(0x0E)] public bool QuestLog;
-        //missing 4
+        //missing 3
+        [MarshalAs(UnmanagedType.U1)]
+        [FieldOffset(0x12)] public bool HasMercenary;
         [MarshalAs(UnmanagedType.U1)]
         [FieldOffset(0x13)] public bool Waypoint;
         //missing 1
@@ -64,5 +66,22 @@ namespace MapAssist.Structs
         [FieldOffset(0x01)] public bool IsItemTooltip;
         [FieldOffset(0x04)] public UnitType UnitType;
         [FieldOffset(0x08)] public uint UnitId;
+    }
+
+    public static class MenuDataExtensions {
+        public static bool IsAnyMenuOpen(this MenuData menuData)
+        {
+            return menuData.Inventory ||
+                menuData.Character ||
+                menuData.SkillSelect ||
+                menuData.SkillTree ||
+                menuData.EscMenu ||
+                menuData.NpcShop ||
+                menuData.QuestLog ||
+                menuData.Waypoint ||
+                menuData.Party ||
+                menuData.Help ||
+                menuData.MercenaryInventory;
+        }
     }
 }

--- a/Types/GameData.cs
+++ b/Types/GameData.cs
@@ -5,6 +5,14 @@ using System.Collections.Generic;
 
 namespace MapAssist.Types
 {
+    public enum MenuPanelState : byte
+    {
+        ClosedAll = 0,
+        RightOpen,
+        LeftOpen,
+        BothOpen
+    }
+
     public class GameData
     {
         public Point PlayerPosition;
@@ -25,7 +33,7 @@ namespace MapAssist.Types
         public ItemLogEntry[] ItemLog;
         public Session Session;
         public Roster Roster;
-        public byte MenuPanelOpen;
+        public MenuPanelState MenuPanelOpen;
         public MenuData MenuOpen;
         public Npc LastNpcInteracted;
         public int ProcessId;


### PR DESCRIPTION
Game info / item log drawing hasn't changed, because it doesn't overlap fullscreen menus.
Fixes #398 

Tested with Steam Gamepad (Xbox layout)