### PR TITLE
fix a bug that itemclass may quote a subitem that make load crash

### DIFF
--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -47,7 +47,9 @@ namespace MapAssist.Settings
                 }
                 else
                 {
-                    foreach (var rule in Filters[itemClass])
+                    // copy it for class may quote the item in class
+                    var rules = new List<ItemFilter>(Filters[itemClass]);
+                    foreach (var rule in rules)
                     {
                         assignRule(rule);
                     }


### PR DESCRIPTION
fix a bug that itemclass may quote a subitem that make load crash

My filter file are not written manually, so maybe a class quote a subitem
Situation:
```  
ScissorsSuwayyah: &o3
  - Tiers:
    - Exceptional
    - Elite
    PlaySoundOnDrop: true
    Qualities:
    - MAGIC
  ClassAssassinKatars: *o3 
```
