### PR TITLE
Add runeword mark for item log

### DIFF
--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -99,7 +99,11 @@ namespace MapAssist.Types
                 itemPrefix += "[Eth] ";
             }
 
-            if (item.Stats.TryGetValue(Stats.Stat.NumSockets, out var numSockets))
+            if (item.IsRuneWord)
+            {
+                itemPrefix += $"[{Items.GetRunewordFromId(item.Prefixes[0])}] ";
+            }
+            else if (item.Stats.TryGetValue(Stats.Stat.NumSockets, out var numSockets))
             {
                 itemPrefix += "[" + numSockets + " S] ";
             }


### PR DESCRIPTION
It can be useful when somebody drops built runeword. 