### PR TITLE
fix: Canyon of the Magi freeze

### DIFF
--- a/Helpers/MapApi.cs
+++ b/Helpers/MapApi.cs
@@ -489,8 +489,11 @@ namespace MapAssist.Helpers
                 _cache[area] = areaData;
                 _log.Info($"Loaded data for {areaData.Area}");
 
-                areaData.PointsOfInterest = PointOfInterestHandler.Get(this, areaData, _gameData);
-                _log.Info($"Found {areaData.PointsOfInterest.Count} points of interest in {areaData.Area}");
+                if (areaData.Area != Area.CanyonOfTheMagi)
+                {
+                    areaData.PointsOfInterest = PointOfInterestHandler.Get(this, areaData, _gameData);
+                    _log.Info($"Found {areaData.PointsOfInterest.Count} points of interest in {areaData.Area}");
+                }
                 
                 return areaData;
             }


### PR DESCRIPTION
Canyon of the Magi seems to cause an infinite loop when tombs are processed in POI Handler:
https://github.com/OneXDeveloper/MapAssist/blob/develop/Helpers/PointOfInterestHandler.cs#L193-L200

This does however prevent the Super Chest from being marked in Canyon