### PR TITLE
Fix for Max Life Percent in ItemFilter

### DIFF
--- a/Types/Stats.cs
+++ b/Types/Stats.cs
@@ -533,7 +533,7 @@ namespace MapAssist.Types
             MaxDurability,
             ReplenishLife,
             MaxDurabilityPercent,
-            MaxHPPercent,
+            MaxLifePercent,
             MaxManaPercent,
             AttackerTakesDamage,
             GoldFind,


### PR DESCRIPTION
Aligns `Stat.MaxLifePercent` with the expected configuration name 
https://github.com/OneXDeveloper/MapAssist/blob/develop/Settings/LootLogConfiguration.cs#L232