### PR TITLE
Fix Trav and Meph Council health bar

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -860,7 +860,7 @@ namespace MapAssist.Helpers
 
                     if (NPC.AreaSpecificSuperUniques.ContainsKey(_areaData.Area))
                     {
-                        superUniques = superUniques.Concat(NPC.AreaSpecificSuperUniques[_areaData.Area].Where(x => x.Value == monsterClass)).ToArray();
+                        superUniques = superUniques.Concat(NPC.AreaSpecificSuperUniques[_areaData.Area].Where(x => x.Value == monster.MonsterData.BossLineID.ToString())).ToArray();
                     }
 
                     if (superUniques.Length == 1 && (monster.MonsterType == MonsterTypeFlags.SuperUnique || monster.MonsterType == MonsterTypeFlags.Unique))

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -856,15 +856,21 @@ namespace MapAssist.Helpers
                 foreach (var monster in _gameData.Monsters)
                 {
                     var monsterClass = Encoding.UTF8.GetString(monster.MonsterStats.Name).TrimEnd((char)0);
-                    var monsterName = NPC.SuperUniques.Where(x => x.Value == monsterClass).ToArray();
+                    var superUniques = NPC.SuperUniques.Where(x => x.Value == monsterClass).ToArray();
 
-                    if (monsterName.Length == 1 && (monster.MonsterData.BossLineID > 0 || monster.Npc == Npc.Summoner)) // Summoner seems to be an odd exception
+                    if (NPC.AreaSpecificSuperUniques.ContainsKey(_areaData.Area))
                     {
-                        monstersAround.Add((monster, NpcExtensions.LocalizedName(monsterName[0].Key)));
+                        superUniques = superUniques.Concat(NPC.AreaSpecificSuperUniques[_areaData.Area].Where(x => x.Value == monsterClass)).ToArray();
+                    }
+
+                    if (superUniques.Length == 1 && (monster.MonsterType == MonsterTypeFlags.SuperUnique || monster.MonsterType == MonsterTypeFlags.Unique))
+                    {
+                        monstersAround.Add((monster, NpcExtensions.LocalizedName(superUniques[0].Key)));
                     }
                 }
 
                 if (monstersAround.Count == 1 && hoveredUnit.Count() == 0) return monstersAround[0];
+                else if (monstersAround.Count > 1 && hoveredUnit.Count() == 0) return monstersAround.OrderBy(m => m.Item1.HealthPercentage).First();
                 else if (monstersAround.Count == 0) return (null, null);
 
                 var hoveredMonster = monstersAround.Where(x => x.Item1.IsHovered).ToArray();

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -856,16 +856,16 @@ namespace MapAssist.Helpers
                 foreach (var monster in _gameData.Monsters)
                 {
                     var monsterClass = Encoding.UTF8.GetString(monster.MonsterStats.Name).TrimEnd((char)0);
-                    var superUniques = NPC.SuperUniques.Where(x => x.Value == monsterClass).ToArray();
+                    var monsterNames = NPC.SuperUniques.Where(x => x.Value == monsterClass).Select(kvp => kvp.Key).ToArray();
 
                     if (NPC.AreaSpecificSuperUniques.ContainsKey(_areaData.Area))
                     {
-                        superUniques = superUniques.Concat(NPC.AreaSpecificSuperUniques[_areaData.Area].Where(x => x.Value == monster.MonsterData.BossLineID.ToString())).ToArray();
+                        monsterNames = monsterNames.Concat(NPC.AreaSpecificSuperUniques[_areaData.Area].Where(x => x.Value == monster.MonsterData.BossLineID).Select(kvp => kvp.Key).ToArray()).ToArray();
                     }
 
-                    if (superUniques.Length == 1 && (monster.MonsterType == MonsterTypeFlags.SuperUnique || monster.MonsterType == MonsterTypeFlags.Unique))
+                    if (monsterNames.Length == 1 && (monster.MonsterType == MonsterTypeFlags.SuperUnique || monster.MonsterType == MonsterTypeFlags.Unique))
                     {
-                        monstersAround.Add((monster, NpcExtensions.LocalizedName(superUniques[0].Key)));
+                        monstersAround.Add((monster, NpcExtensions.LocalizedName(monsterNames[0])));
                     }
                 }
 

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -856,11 +856,11 @@ namespace MapAssist.Helpers
                 foreach (var monster in _gameData.Monsters)
                 {
                     var monsterClass = Encoding.UTF8.GetString(monster.MonsterStats.Name).TrimEnd((char)0);
-                    var monsterNames = NPC.SuperUniques.Where(x => x.Value == monsterClass).Select(kvp => kvp.Key).ToArray();
+                    var monsterNames = NPC.SuperUniques.Where(x => x.Value == monsterClass).Select(x => x.Key).ToArray();
 
                     if (NPC.AreaSpecificSuperUniques.ContainsKey(_areaData.Area))
                     {
-                        monsterNames = monsterNames.Concat(NPC.AreaSpecificSuperUniques[_areaData.Area].Where(x => x.Value == monster.MonsterData.BossLineID).Select(kvp => kvp.Key).ToArray()).ToArray();
+                        monsterNames = monsterNames.Concat(NPC.AreaSpecificSuperUniques[_areaData.Area].Where(x => x.Value == monster.MonsterData.BossLineID).Select(x => x.Key).ToArray()).ToArray();
                     }
 
                     if (monsterNames.Length == 1 && (monster.MonsterType == MonsterTypeFlags.SuperUnique || monster.MonsterType == MonsterTypeFlags.Unique))

--- a/Types/NPC.cs
+++ b/Types/NPC.cs
@@ -164,19 +164,19 @@ namespace MapAssist.Types
             { "Baal Subject 5", "baalminion1" },
         };
 
-        public static Dictionary<Area, Dictionary<string, string>> AreaSpecificSuperUniques = new Dictionary<Area, Dictionary<string, string>>()
+        public static Dictionary<Area, Dictionary<string, int>> AreaSpecificSuperUniques = new Dictionary<Area, Dictionary<string, int>>()
         {
-            [Area.Travincal] = new Dictionary<string, string>()
+            [Area.Travincal] = new Dictionary<string, int>()
             {
-                { "Toorc Icefist", "29" },
-                { "Geleb Flamefinger", "27" },
-                { "Ismail Vilehand", "26" },
+                { "Ismail Vilehand", 26 },
+                { "Geleb Flamefinger", 27 },
+                { "Toorc Icefist", 29 },
             },
-            [Area.DuranceOfHateLevel3] = new Dictionary<string, string>()
+            [Area.DuranceOfHateLevel3] = new Dictionary<string, int>()
             {
-                { "Wyand Voidfinger", "30" },
-                { "Maffer Dragonhand", "31" },
-                { "Bremm Sparkfist", "28" },
+                { "Bremm Sparkfist", 28 },
+                { "Wyand Voidfinger", 30 },
+                { "Maffer Dragonhand", 31 },
             }
         };
     }

--- a/Types/NPC.cs
+++ b/Types/NPC.cs
@@ -129,12 +129,6 @@ namespace MapAssist.Types
             { "Stormtree", "thornhulk3" },
             { "Sarina the Battlemaid", "corruptrogue5" },
             { "Icehawk Riftwing", "batdemon3" },
-            //{ "Ismail Vilehand", "councilmember1" },
-            //{ "Geleb Flamefinger", "councilmember2" },
-            //{ "Bremm Sparkfist", "councilmember3" },
-            //{ "Toorc Icefist", "councilmember1" },
-            //{ "Wyand Voidfinger", "councilmember2" },
-            //{ "Maffer Dragonhand", "councilmember3" },
             //{ "Winged Death", "megademon3" },
             { "The Tormentor", "willowisp3" },
             { "Taintbreeder", "vilemother2" },
@@ -168,6 +162,22 @@ namespace MapAssist.Types
             { "Baal Subject 3", "baalhighpriest" },
             { "Baal Subject 4", "venomlord" },
             { "Baal Subject 5", "baalminion1" },
+        };
+
+        public static Dictionary<Area, Dictionary<string, string>> AreaSpecificSuperUniques = new Dictionary<Area, Dictionary<string, string>>()
+        {
+            [Area.Travincal] = new Dictionary<string, string>()
+            {
+                { "Ismail Vilehand", "councilmember1" },
+                { "Geleb Flamefinger", "councilmember2" },
+                { "Bremm Sparkfist", "councilmember3" },
+            },
+            [Area.DuranceOfHateLevel3] = new Dictionary<string, string>()
+            {
+                { "Toorc Icefist", "councilmember1" },
+                { "Wyand Voidfinger", "councilmember2" },
+                { "Maffer Dragonhand", "councilmember3" },
+            }
         };
     }
 

--- a/Types/NPC.cs
+++ b/Types/NPC.cs
@@ -168,15 +168,15 @@ namespace MapAssist.Types
         {
             [Area.Travincal] = new Dictionary<string, string>()
             {
-                { "Ismail Vilehand", "councilmember1" },
-                { "Geleb Flamefinger", "councilmember2" },
-                { "Bremm Sparkfist", "councilmember3" },
+                { "Toorc Icefist", "29" },
+                { "Geleb Flamefinger", "27" },
+                { "Ismail Vilehand", "26" },
             },
             [Area.DuranceOfHateLevel3] = new Dictionary<string, string>()
             {
-                { "Toorc Icefist", "councilmember1" },
-                { "Wyand Voidfinger", "councilmember2" },
-                { "Maffer Dragonhand", "councilmember3" },
+                { "Wyand Voidfinger", "30" },
+                { "Maffer Dragonhand", "31" },
+                { "Bremm Sparkfist", "28" },
             }
         };
     }


### PR DESCRIPTION
Moved Trav and Durance council members to an `AreaSpecificSuperUniques` dictionary that matches on BossLineID

When multiple Super Uniques are nearby (such as Trav or Durance Level 3) and no other monster is hovered, defaults to showing the monster health bar for the monster with lowest HP

Checking `MonsterType` instead of `BossLineID` fixes Bishibosh

### Trav showing lowest HP council member
![trav1](https://user-images.githubusercontent.com/10291543/169662961-ae6aaada-94ba-4e96-99ff-b68ec4d3dd28.png)

### Meph with only 1 super unique nearby
![meph1](https://user-images.githubusercontent.com/10291543/169664844-8392dea6-3727-4b3e-b520-50320cba1c6e.png)

### Meph with 2 super uniques nearby, top-right one has lower health
![meph2](https://user-images.githubusercontent.com/10291543/169662980-80b05722-c71d-4ac9-b95a-b5431bbb9503.png)