### PR TITLE
Fix Trade item log spam

### DIFF
--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -70,7 +70,7 @@ namespace MapAssist.Types
 
         public static bool CheckInventoryItem(UnitItem item, int processId) =>
             MapAssistConfiguration.Loaded.ItemLog.CheckItemOnIdentify &&
-            item.IsIdentified && item.IsPlayerOwned && !item.IsInSocket &&
+            item.IsIdentified && item.IsPlayerOwned && item.IsInInventory &&
             !InventoryItemUnitIdsToSkip[processId].Contains(item.UnitId);
 
         public static bool CheckDroppedItem(UnitItem item, int processId) =>

--- a/Types/UnitItem.cs
+++ b/Types/UnitItem.cs
@@ -56,6 +56,8 @@ namespace MapAssist.Types
 
         public bool IsDropped => ItemModeMapped == ItemModeMapped.Ground;
 
+        public bool IsInInventory => ItemModeMapped == ItemModeMapped.Inventory;
+
         public bool IsInStore => ItemModeMapped == ItemModeMapped.Vendor;
 
         public bool IsInSocket => ItemModeMapped == ItemModeMapped.Socket;


### PR DESCRIPTION
This prevents loot log alerts for items in the trade window.

I tested unid drop alerts, vendor trades, identifying in inventory, cube transmuting, player trading, weapon swap with two clients in the same game (previous trigger for a fixed bug) and it seems everything works as expected.