### PR TITLE
Added act boss kill tracker

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -21,8 +21,8 @@ RenderingConfiguration:
   Size: 800
   ZoomLevel: 1
   BuffSize: 1
-  BuffPosition: Bottom
   BuffAlertLowRes: true
+  BuffPosition: Bottom
   ShowLife: false
   ShowLifePerc: true
   ShowMana: false
@@ -216,7 +216,7 @@ MapConfiguration:
     IconShape: Ellipse
     IconSize: 0
   MissileFireLarge:
-    IconColor: 255, 0, 0
+    IconColor: Red
     IconShape: Ellipse
     IconSize: 0
   MissileFireSmall:
@@ -232,7 +232,7 @@ MapConfiguration:
     IconShape: Ellipse
     IconSize: 0
   MissileLightLarge:
-    IconColor: 255, 255, 0
+    IconColor: Yellow
     IconShape: Ellipse
     IconSize: 0
   MissileLightSmall:
@@ -240,7 +240,7 @@ MapConfiguration:
     IconShape: Ellipse
     IconSize: 0
   MissilePoisonLarge:
-    IconColor: 0, 255, 0
+    IconColor: Lime
     IconShape: Ellipse
     IconSize: 0
   MissilePoisonSmall:
@@ -270,14 +270,20 @@ ItemLog:
   LabelFont: Exocet Blizzard Mixed Caps
   LabelFontSize: 16
   LabelTextShadow: true
+  SuperiorColor: Gray
+  MagicColor: RoyalBlue
+  RareColor: Yellow
+  SetColor: Lime
+  UniqueColor: 165, 146, 99
+  CraftedColor: 255, 174, 0
 MapColorConfiguration:
-  Border: 255, 255, 255
+  Border: White
 GameInfo:
   Position: TopLeft
   ShowGameName: true
-  ShowDifficulty: true
   ShowArea: true
   ShowAreaLevel: true
+  ShowDifficulty: true
   ShowOverlayFPS: false
   ShowGameTimer: true
   ShowAreaTimer: true

--- a/Config.yaml
+++ b/Config.yaml
@@ -21,6 +21,10 @@ RenderingConfiguration:
   Size: 800
   ZoomLevel: 1
   BuffSize: 1
+  ShowBuffBarBuffs: true
+  ShowBuffBarAuras: true
+  ShowBuffBarPassives: true
+  ShowBuffBarDebuffs: true
   BuffAlertLowRes: true
   BuffPosition: Bottom
   ShowLife: false

--- a/Config.yaml
+++ b/Config.yaml
@@ -10,7 +10,7 @@ HiddenAreas:
 - Forgotten Tower
 AuthorizedWindowTitles: []
 RenderingConfiguration:
-  Opacity: 0.5
+  Opacity: 0.3
   IconOpacity: 0.9
   OverlayMode: true
   Position: Center

--- a/Files/ConfigurationParser.cs
+++ b/Files/ConfigurationParser.cs
@@ -162,6 +162,7 @@ namespace MapAssist.Files
                     .WithTypeConverter(new PointOfInterestRenderingTypeConverter())
                     .WithTypeConverter(new PortalRenderingTypeConverter())
                     .WithTypeConverter(new MapColorConfigurationTypeConverter())
+                    .WithTypeConverter(new ColorConfigurationTypeConverter())
                     .Build();
                 serializer.Serialize(streamWriter, config);
             }

--- a/Forms/AddAreaForm.cs
+++ b/Forms/AddAreaForm.cs
@@ -44,7 +44,7 @@ namespace MapAssist
             var list = formParent.Controls.Find(listToAddTo, true).FirstOrDefault() as ListBox;
             if (!list.Items.Contains(areaName))
             {
-                list.Items.Add(areaName);
+                list.Items.Add(AreaExtensions.Name(areaToAdd));
                 switch (listToAddTo)
                 {
                     case "lstHidden":

--- a/Forms/ConfigEditor.Designer.cs
+++ b/Forms/ConfigEditor.Designer.cs
@@ -90,6 +90,10 @@
             this.lblMapLinesMode = new System.Windows.Forms.Label();
             this.cboMapLinesMode = new System.Windows.Forms.ComboBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.chkDebuffs = new System.Windows.Forms.CheckBox();
+            this.chkPassives = new System.Windows.Forms.CheckBox();
+            this.chkAuras = new System.Windows.Forms.CheckBox();
+            this.chkBuffs = new System.Windows.Forms.CheckBox();
             this.chkAlertLowerRes = new System.Windows.Forms.CheckBox();
             this.lblBuffSizeValue = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
@@ -130,6 +134,18 @@
             this.cboRenderOption = new System.Windows.Forms.ComboBox();
             this.tabPage6 = new System.Windows.Forms.TabPage();
             this.groupBox6 = new System.Windows.Forms.GroupBox();
+            this.btnClearSuperiorColor = new System.Windows.Forms.Button();
+            this.btnSuperiorColor = new System.Windows.Forms.Button();
+            this.btnClearUniqueColor = new System.Windows.Forms.Button();
+            this.btnUniqueColor = new System.Windows.Forms.Button();
+            this.btnClearSetColor = new System.Windows.Forms.Button();
+            this.btnSetColor = new System.Windows.Forms.Button();
+            this.btnClearCraftedColor = new System.Windows.Forms.Button();
+            this.btnCraftedColor = new System.Windows.Forms.Button();
+            this.btnClearRareColor = new System.Windows.Forms.Button();
+            this.btnRareColor = new System.Windows.Forms.Button();
+            this.btnClearMagicColor = new System.Windows.Forms.Button();
+            this.btnMagicColor = new System.Windows.Forms.Button();
             this.chkShowDirectionToItem = new System.Windows.Forms.CheckBox();
             this.chkShowDistanceToItem = new System.Windows.Forms.CheckBox();
             this.chkItemLogVendorItems = new System.Windows.Forms.CheckBox();
@@ -181,18 +197,6 @@
             this.label3 = new System.Windows.Forms.Label();
             this.chkDPIAware = new System.Windows.Forms.CheckBox();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
-            this.btnClearMagicColor = new System.Windows.Forms.Button();
-            this.btnMagicColor = new System.Windows.Forms.Button();
-            this.btnClearRareColor = new System.Windows.Forms.Button();
-            this.btnRareColor = new System.Windows.Forms.Button();
-            this.btnClearCraftedColor = new System.Windows.Forms.Button();
-            this.btnCraftedColor = new System.Windows.Forms.Button();
-            this.btnClearSetColor = new System.Windows.Forms.Button();
-            this.btnSetColor = new System.Windows.Forms.Button();
-            this.btnClearUniqueColor = new System.Windows.Forms.Button();
-            this.btnUniqueColor = new System.Windows.Forms.Button();
-            this.btnClearSuperiorColor = new System.Windows.Forms.Button();
-            this.btnSuperiorColor = new System.Windows.Forms.Button();
             this.tabControl1.SuspendLayout();
             this.tabPage5.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -858,7 +862,7 @@
             this.groupBox7.Controls.Add(this.chkMana);
             this.groupBox7.Controls.Add(this.chkLifePerc);
             this.groupBox7.Controls.Add(this.chkLife);
-            this.groupBox7.Location = new System.Drawing.Point(11, 143);
+            this.groupBox7.Location = new System.Drawing.Point(11, 153);
             this.groupBox7.Name = "groupBox7";
             this.groupBox7.Size = new System.Drawing.Size(388, 90);
             this.groupBox7.TabIndex = 25;
@@ -992,6 +996,10 @@
             // 
             this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox3.Controls.Add(this.chkDebuffs);
+            this.groupBox3.Controls.Add(this.chkPassives);
+            this.groupBox3.Controls.Add(this.chkAuras);
+            this.groupBox3.Controls.Add(this.chkBuffs);
             this.groupBox3.Controls.Add(this.chkAlertLowerRes);
             this.groupBox3.Controls.Add(this.lblBuffSizeValue);
             this.groupBox3.Controls.Add(this.label5);
@@ -1000,15 +1008,59 @@
             this.groupBox3.Controls.Add(this.buffSize);
             this.groupBox3.Location = new System.Drawing.Point(11, 9);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(388, 107);
+            this.groupBox3.Size = new System.Drawing.Size(388, 125);
             this.groupBox3.TabIndex = 23;
             this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Buffs";
+            this.groupBox3.Text = "Buff Bar";
+            // 
+            // chkDebuffs
+            // 
+            this.chkDebuffs.AutoSize = true;
+            this.chkDebuffs.Location = new System.Drawing.Point(198, 78);
+            this.chkDebuffs.Name = "chkDebuffs";
+            this.chkDebuffs.Size = new System.Drawing.Size(63, 17);
+            this.chkDebuffs.TabIndex = 29;
+            this.chkDebuffs.Text = "Debuffs";
+            this.chkDebuffs.UseVisualStyleBackColor = true;
+            this.chkDebuffs.CheckedChanged += new System.EventHandler(this.chkDebuffs_CheckedChanged);
+            // 
+            // chkPassives
+            // 
+            this.chkPassives.AutoSize = true;
+            this.chkPassives.Location = new System.Drawing.Point(124, 78);
+            this.chkPassives.Name = "chkPassives";
+            this.chkPassives.Size = new System.Drawing.Size(68, 17);
+            this.chkPassives.TabIndex = 28;
+            this.chkPassives.Text = "Passives";
+            this.chkPassives.UseVisualStyleBackColor = true;
+            this.chkPassives.CheckedChanged += new System.EventHandler(this.chkPassives_CheckedChanged);
+            // 
+            // chkAuras
+            // 
+            this.chkAuras.AutoSize = true;
+            this.chkAuras.Location = new System.Drawing.Point(65, 78);
+            this.chkAuras.Name = "chkAuras";
+            this.chkAuras.Size = new System.Drawing.Size(53, 17);
+            this.chkAuras.TabIndex = 27;
+            this.chkAuras.Text = "Auras";
+            this.chkAuras.UseVisualStyleBackColor = true;
+            this.chkAuras.CheckedChanged += new System.EventHandler(this.chkAuras_CheckedChanged);
+            // 
+            // chkBuffs
+            // 
+            this.chkBuffs.AutoSize = true;
+            this.chkBuffs.Location = new System.Drawing.Point(9, 78);
+            this.chkBuffs.Name = "chkBuffs";
+            this.chkBuffs.Size = new System.Drawing.Size(50, 17);
+            this.chkBuffs.TabIndex = 26;
+            this.chkBuffs.Text = "Buffs";
+            this.chkBuffs.UseVisualStyleBackColor = true;
+            this.chkBuffs.CheckedChanged += new System.EventHandler(this.chkBuffs_CheckedChanged);
             // 
             // chkAlertLowerRes
             // 
             this.chkAlertLowerRes.AutoSize = true;
-            this.chkAlertLowerRes.Location = new System.Drawing.Point(9, 78);
+            this.chkAlertLowerRes.Location = new System.Drawing.Point(9, 101);
             this.chkAlertLowerRes.Name = "chkAlertLowerRes";
             this.chkAlertLowerRes.Size = new System.Drawing.Size(161, 17);
             this.chkAlertLowerRes.TabIndex = 23;
@@ -1033,9 +1085,9 @@
             this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(6, 54);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(85, 13);
+            this.label5.Size = new System.Drawing.Size(44, 13);
             this.label5.TabIndex = 19;
-            this.label5.Text = "Buff Bar Position";
+            this.label5.Text = "Position";
             // 
             // lblBuffSize
             // 
@@ -1052,7 +1104,7 @@
             this.cboBuffPosition.AllowDrop = true;
             this.cboBuffPosition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboBuffPosition.FormattingEnabled = true;
-            this.cboBuffPosition.Location = new System.Drawing.Point(102, 51);
+            this.cboBuffPosition.Location = new System.Drawing.Point(56, 51);
             this.cboBuffPosition.Name = "cboBuffPosition";
             this.cboBuffPosition.Size = new System.Drawing.Size(124, 21);
             this.cboBuffPosition.TabIndex = 18;
@@ -1539,6 +1591,150 @@
             this.groupBox6.TabIndex = 0;
             this.groupBox6.TabStop = false;
             this.groupBox6.Text = "Item Log";
+            // 
+            // btnClearSuperiorColor
+            // 
+            this.btnClearSuperiorColor.FlatAppearance.BorderSize = 0;
+            this.btnClearSuperiorColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearSuperiorColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearSuperiorColor.Location = new System.Drawing.Point(188, 238);
+            this.btnClearSuperiorColor.Name = "btnClearSuperiorColor";
+            this.btnClearSuperiorColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearSuperiorColor.TabIndex = 53;
+            this.btnClearSuperiorColor.Text = "X";
+            this.btnClearSuperiorColor.UseVisualStyleBackColor = true;
+            this.btnClearSuperiorColor.Click += new System.EventHandler(this.btnClearSuperiorColor_Click);
+            // 
+            // btnSuperiorColor
+            // 
+            this.btnSuperiorColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnSuperiorColor.Location = new System.Drawing.Point(131, 238);
+            this.btnSuperiorColor.Name = "btnSuperiorColor";
+            this.btnSuperiorColor.Size = new System.Drawing.Size(56, 23);
+            this.btnSuperiorColor.TabIndex = 54;
+            this.btnSuperiorColor.Text = "Superior";
+            this.btnSuperiorColor.UseVisualStyleBackColor = true;
+            this.btnSuperiorColor.Click += new System.EventHandler(this.btnSuperiorColor_Click);
+            // 
+            // btnClearUniqueColor
+            // 
+            this.btnClearUniqueColor.FlatAppearance.BorderSize = 0;
+            this.btnClearUniqueColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearUniqueColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearUniqueColor.Location = new System.Drawing.Point(274, 271);
+            this.btnClearUniqueColor.Name = "btnClearUniqueColor";
+            this.btnClearUniqueColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearUniqueColor.TabIndex = 51;
+            this.btnClearUniqueColor.Text = "X";
+            this.btnClearUniqueColor.UseVisualStyleBackColor = true;
+            this.btnClearUniqueColor.Click += new System.EventHandler(this.btnClearUniqueColor_Click);
+            // 
+            // btnUniqueColor
+            // 
+            this.btnUniqueColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnUniqueColor.Location = new System.Drawing.Point(217, 271);
+            this.btnUniqueColor.Name = "btnUniqueColor";
+            this.btnUniqueColor.Size = new System.Drawing.Size(56, 23);
+            this.btnUniqueColor.TabIndex = 52;
+            this.btnUniqueColor.Text = "Unique";
+            this.btnUniqueColor.UseVisualStyleBackColor = true;
+            this.btnUniqueColor.Click += new System.EventHandler(this.btnUniqueColor_Click);
+            // 
+            // btnClearSetColor
+            // 
+            this.btnClearSetColor.FlatAppearance.BorderSize = 0;
+            this.btnClearSetColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearSetColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearSetColor.Location = new System.Drawing.Point(188, 271);
+            this.btnClearSetColor.Name = "btnClearSetColor";
+            this.btnClearSetColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearSetColor.TabIndex = 49;
+            this.btnClearSetColor.Text = "X";
+            this.btnClearSetColor.UseVisualStyleBackColor = true;
+            this.btnClearSetColor.Click += new System.EventHandler(this.btnClearSetColor_Click);
+            // 
+            // btnSetColor
+            // 
+            this.btnSetColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnSetColor.Location = new System.Drawing.Point(131, 271);
+            this.btnSetColor.Name = "btnSetColor";
+            this.btnSetColor.Size = new System.Drawing.Size(56, 23);
+            this.btnSetColor.TabIndex = 50;
+            this.btnSetColor.Text = "Set";
+            this.btnSetColor.UseVisualStyleBackColor = true;
+            this.btnSetColor.Click += new System.EventHandler(this.btnSetColor_Click);
+            // 
+            // btnClearCraftedColor
+            // 
+            this.btnClearCraftedColor.FlatAppearance.BorderSize = 0;
+            this.btnClearCraftedColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearCraftedColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearCraftedColor.Location = new System.Drawing.Point(360, 271);
+            this.btnClearCraftedColor.Name = "btnClearCraftedColor";
+            this.btnClearCraftedColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearCraftedColor.TabIndex = 47;
+            this.btnClearCraftedColor.Text = "X";
+            this.btnClearCraftedColor.UseVisualStyleBackColor = true;
+            this.btnClearCraftedColor.Click += new System.EventHandler(this.btnClearCraftedColor_Click);
+            // 
+            // btnCraftedColor
+            // 
+            this.btnCraftedColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnCraftedColor.Location = new System.Drawing.Point(303, 271);
+            this.btnCraftedColor.Name = "btnCraftedColor";
+            this.btnCraftedColor.Size = new System.Drawing.Size(56, 23);
+            this.btnCraftedColor.TabIndex = 48;
+            this.btnCraftedColor.Text = "Crafted";
+            this.btnCraftedColor.UseVisualStyleBackColor = true;
+            this.btnCraftedColor.Click += new System.EventHandler(this.btnCraftedColor_Click);
+            // 
+            // btnClearRareColor
+            // 
+            this.btnClearRareColor.FlatAppearance.BorderSize = 0;
+            this.btnClearRareColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearRareColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearRareColor.Location = new System.Drawing.Point(360, 238);
+            this.btnClearRareColor.Name = "btnClearRareColor";
+            this.btnClearRareColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearRareColor.TabIndex = 45;
+            this.btnClearRareColor.Text = "X";
+            this.btnClearRareColor.UseVisualStyleBackColor = true;
+            this.btnClearRareColor.Click += new System.EventHandler(this.btnClearRareColor_Click);
+            // 
+            // btnRareColor
+            // 
+            this.btnRareColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnRareColor.Location = new System.Drawing.Point(303, 238);
+            this.btnRareColor.Name = "btnRareColor";
+            this.btnRareColor.Size = new System.Drawing.Size(56, 23);
+            this.btnRareColor.TabIndex = 46;
+            this.btnRareColor.Text = "Rare";
+            this.btnRareColor.UseVisualStyleBackColor = true;
+            this.btnRareColor.Click += new System.EventHandler(this.btnRareColor_Click);
+            // 
+            // btnClearMagicColor
+            // 
+            this.btnClearMagicColor.FlatAppearance.BorderSize = 0;
+            this.btnClearMagicColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearMagicColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearMagicColor.Location = new System.Drawing.Point(274, 238);
+            this.btnClearMagicColor.Name = "btnClearMagicColor";
+            this.btnClearMagicColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearMagicColor.TabIndex = 43;
+            this.btnClearMagicColor.Text = "X";
+            this.btnClearMagicColor.UseVisualStyleBackColor = true;
+            this.btnClearMagicColor.Click += new System.EventHandler(this.btnClearMagicColor_Click);
+            // 
+            // btnMagicColor
+            // 
+            this.btnMagicColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnMagicColor.Location = new System.Drawing.Point(217, 238);
+            this.btnMagicColor.Name = "btnMagicColor";
+            this.btnMagicColor.Size = new System.Drawing.Size(56, 23);
+            this.btnMagicColor.TabIndex = 44;
+            this.btnMagicColor.Text = "Magic";
+            this.btnMagicColor.UseVisualStyleBackColor = true;
+            this.btnMagicColor.Click += new System.EventHandler(this.btnMagicColor_Click);
             // 
             // chkShowDirectionToItem
             // 
@@ -2098,150 +2294,6 @@
             this.chkDPIAware.UseVisualStyleBackColor = true;
             this.chkDPIAware.CheckedChanged += new System.EventHandler(this.chkDPIAware_CheckedChanged);
             // 
-            // btnClearMagicColor
-            // 
-            this.btnClearMagicColor.FlatAppearance.BorderSize = 0;
-            this.btnClearMagicColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnClearMagicColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
-            this.btnClearMagicColor.Location = new System.Drawing.Point(274, 238);
-            this.btnClearMagicColor.Name = "btnClearMagicColor";
-            this.btnClearMagicColor.Size = new System.Drawing.Size(23, 23);
-            this.btnClearMagicColor.TabIndex = 43;
-            this.btnClearMagicColor.Text = "X";
-            this.btnClearMagicColor.UseVisualStyleBackColor = true;
-            this.btnClearMagicColor.Click += new System.EventHandler(this.btnClearMagicColor_Click);
-            // 
-            // btnMagicColor
-            // 
-            this.btnMagicColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnMagicColor.Location = new System.Drawing.Point(217, 238);
-            this.btnMagicColor.Name = "btnMagicColor";
-            this.btnMagicColor.Size = new System.Drawing.Size(56, 23);
-            this.btnMagicColor.TabIndex = 44;
-            this.btnMagicColor.Text = "Magic";
-            this.btnMagicColor.UseVisualStyleBackColor = true;
-            this.btnMagicColor.Click += new System.EventHandler(this.btnMagicColor_Click);
-            // 
-            // btnClearRareColor
-            // 
-            this.btnClearRareColor.FlatAppearance.BorderSize = 0;
-            this.btnClearRareColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnClearRareColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
-            this.btnClearRareColor.Location = new System.Drawing.Point(360, 238);
-            this.btnClearRareColor.Name = "btnClearRareColor";
-            this.btnClearRareColor.Size = new System.Drawing.Size(23, 23);
-            this.btnClearRareColor.TabIndex = 45;
-            this.btnClearRareColor.Text = "X";
-            this.btnClearRareColor.UseVisualStyleBackColor = true;
-            this.btnClearRareColor.Click += new System.EventHandler(this.btnClearRareColor_Click);
-            // 
-            // btnRareColor
-            // 
-            this.btnRareColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnRareColor.Location = new System.Drawing.Point(303, 238);
-            this.btnRareColor.Name = "btnRareColor";
-            this.btnRareColor.Size = new System.Drawing.Size(56, 23);
-            this.btnRareColor.TabIndex = 46;
-            this.btnRareColor.Text = "Rare";
-            this.btnRareColor.UseVisualStyleBackColor = true;
-            this.btnRareColor.Click += new System.EventHandler(this.btnRareColor_Click);
-            // 
-            // btnClearCraftedColor
-            // 
-            this.btnClearCraftedColor.FlatAppearance.BorderSize = 0;
-            this.btnClearCraftedColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnClearCraftedColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
-            this.btnClearCraftedColor.Location = new System.Drawing.Point(360, 271);
-            this.btnClearCraftedColor.Name = "btnClearCraftedColor";
-            this.btnClearCraftedColor.Size = new System.Drawing.Size(23, 23);
-            this.btnClearCraftedColor.TabIndex = 47;
-            this.btnClearCraftedColor.Text = "X";
-            this.btnClearCraftedColor.UseVisualStyleBackColor = true;
-            this.btnClearCraftedColor.Click += new System.EventHandler(this.btnClearCraftedColor_Click);
-            // 
-            // btnCraftedColor
-            // 
-            this.btnCraftedColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCraftedColor.Location = new System.Drawing.Point(303, 271);
-            this.btnCraftedColor.Name = "btnCraftedColor";
-            this.btnCraftedColor.Size = new System.Drawing.Size(56, 23);
-            this.btnCraftedColor.TabIndex = 48;
-            this.btnCraftedColor.Text = "Crafted";
-            this.btnCraftedColor.UseVisualStyleBackColor = true;
-            this.btnCraftedColor.Click += new System.EventHandler(this.btnCraftedColor_Click);
-            // 
-            // btnClearSetColor
-            // 
-            this.btnClearSetColor.FlatAppearance.BorderSize = 0;
-            this.btnClearSetColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnClearSetColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
-            this.btnClearSetColor.Location = new System.Drawing.Point(188, 271);
-            this.btnClearSetColor.Name = "btnClearSetColor";
-            this.btnClearSetColor.Size = new System.Drawing.Size(23, 23);
-            this.btnClearSetColor.TabIndex = 49;
-            this.btnClearSetColor.Text = "X";
-            this.btnClearSetColor.UseVisualStyleBackColor = true;
-            this.btnClearSetColor.Click += new System.EventHandler(this.btnClearSetColor_Click);
-            // 
-            // btnSetColor
-            // 
-            this.btnSetColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSetColor.Location = new System.Drawing.Point(131, 271);
-            this.btnSetColor.Name = "btnSetColor";
-            this.btnSetColor.Size = new System.Drawing.Size(56, 23);
-            this.btnSetColor.TabIndex = 50;
-            this.btnSetColor.Text = "Set";
-            this.btnSetColor.UseVisualStyleBackColor = true;
-            this.btnSetColor.Click += new System.EventHandler(this.btnSetColor_Click);
-            // 
-            // btnClearUniqueColor
-            // 
-            this.btnClearUniqueColor.FlatAppearance.BorderSize = 0;
-            this.btnClearUniqueColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnClearUniqueColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
-            this.btnClearUniqueColor.Location = new System.Drawing.Point(274, 271);
-            this.btnClearUniqueColor.Name = "btnClearUniqueColor";
-            this.btnClearUniqueColor.Size = new System.Drawing.Size(23, 23);
-            this.btnClearUniqueColor.TabIndex = 51;
-            this.btnClearUniqueColor.Text = "X";
-            this.btnClearUniqueColor.UseVisualStyleBackColor = true;
-            this.btnClearUniqueColor.Click += new System.EventHandler(this.btnClearUniqueColor_Click);
-            // 
-            // btnUniqueColor
-            // 
-            this.btnUniqueColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnUniqueColor.Location = new System.Drawing.Point(217, 271);
-            this.btnUniqueColor.Name = "btnUniqueColor";
-            this.btnUniqueColor.Size = new System.Drawing.Size(56, 23);
-            this.btnUniqueColor.TabIndex = 52;
-            this.btnUniqueColor.Text = "Unique";
-            this.btnUniqueColor.UseVisualStyleBackColor = true;
-            this.btnUniqueColor.Click += new System.EventHandler(this.btnUniqueColor_Click);
-            // 
-            // btnClearSuperiorColor
-            // 
-            this.btnClearSuperiorColor.FlatAppearance.BorderSize = 0;
-            this.btnClearSuperiorColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnClearSuperiorColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
-            this.btnClearSuperiorColor.Location = new System.Drawing.Point(188, 238);
-            this.btnClearSuperiorColor.Name = "btnClearSuperiorColor";
-            this.btnClearSuperiorColor.Size = new System.Drawing.Size(23, 23);
-            this.btnClearSuperiorColor.TabIndex = 53;
-            this.btnClearSuperiorColor.Text = "X";
-            this.btnClearSuperiorColor.UseVisualStyleBackColor = true;
-            this.btnClearSuperiorColor.Click += new System.EventHandler(this.btnClearSuperiorColor_Click);
-            // 
-            // btnSuperiorColor
-            // 
-            this.btnSuperiorColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSuperiorColor.Location = new System.Drawing.Point(131, 238);
-            this.btnSuperiorColor.Name = "btnSuperiorColor";
-            this.btnSuperiorColor.Size = new System.Drawing.Size(56, 23);
-            this.btnSuperiorColor.TabIndex = 54;
-            this.btnSuperiorColor.Text = "Superior";
-            this.btnSuperiorColor.UseVisualStyleBackColor = true;
-            this.btnSuperiorColor.Click += new System.EventHandler(this.btnSuperiorColor_Click);
-            // 
             // ConfigEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -2475,5 +2527,9 @@
         private System.Windows.Forms.Button btnCraftedColor;
         private System.Windows.Forms.Button btnClearSuperiorColor;
         private System.Windows.Forms.Button btnSuperiorColor;
+        private System.Windows.Forms.CheckBox chkBuffs;
+        private System.Windows.Forms.CheckBox chkDebuffs;
+        private System.Windows.Forms.CheckBox chkPassives;
+        private System.Windows.Forms.CheckBox chkAuras;
     }
 }

--- a/Forms/ConfigEditor.Designer.cs
+++ b/Forms/ConfigEditor.Designer.cs
@@ -130,6 +130,7 @@
             this.cboRenderOption = new System.Windows.Forms.ComboBox();
             this.tabPage6 = new System.Windows.Forms.TabPage();
             this.groupBox6 = new System.Windows.Forms.GroupBox();
+            this.chkShowDirectionToItem = new System.Windows.Forms.CheckBox();
             this.chkShowDistanceToItem = new System.Windows.Forms.CheckBox();
             this.chkItemLogVendorItems = new System.Windows.Forms.CheckBox();
             this.lblSoundVolumeValue = new System.Windows.Forms.Label();
@@ -180,7 +181,18 @@
             this.label3 = new System.Windows.Forms.Label();
             this.chkDPIAware = new System.Windows.Forms.CheckBox();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
-            this.chkShowDirectionToItem = new System.Windows.Forms.CheckBox();
+            this.btnClearMagicColor = new System.Windows.Forms.Button();
+            this.btnMagicColor = new System.Windows.Forms.Button();
+            this.btnClearRareColor = new System.Windows.Forms.Button();
+            this.btnRareColor = new System.Windows.Forms.Button();
+            this.btnClearCraftedColor = new System.Windows.Forms.Button();
+            this.btnCraftedColor = new System.Windows.Forms.Button();
+            this.btnClearSetColor = new System.Windows.Forms.Button();
+            this.btnSetColor = new System.Windows.Forms.Button();
+            this.btnClearUniqueColor = new System.Windows.Forms.Button();
+            this.btnUniqueColor = new System.Windows.Forms.Button();
+            this.btnClearSuperiorColor = new System.Windows.Forms.Button();
+            this.btnSuperiorColor = new System.Windows.Forms.Button();
             this.tabControl1.SuspendLayout();
             this.tabPage5.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -1486,6 +1498,18 @@
             // 
             this.groupBox6.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox6.Controls.Add(this.btnClearSuperiorColor);
+            this.groupBox6.Controls.Add(this.btnSuperiorColor);
+            this.groupBox6.Controls.Add(this.btnClearUniqueColor);
+            this.groupBox6.Controls.Add(this.btnUniqueColor);
+            this.groupBox6.Controls.Add(this.btnClearSetColor);
+            this.groupBox6.Controls.Add(this.btnSetColor);
+            this.groupBox6.Controls.Add(this.btnClearCraftedColor);
+            this.groupBox6.Controls.Add(this.btnCraftedColor);
+            this.groupBox6.Controls.Add(this.btnClearRareColor);
+            this.groupBox6.Controls.Add(this.btnRareColor);
+            this.groupBox6.Controls.Add(this.btnClearMagicColor);
+            this.groupBox6.Controls.Add(this.btnMagicColor);
             this.groupBox6.Controls.Add(this.chkShowDirectionToItem);
             this.groupBox6.Controls.Add(this.chkShowDistanceToItem);
             this.groupBox6.Controls.Add(this.chkItemLogVendorItems);
@@ -1516,10 +1540,21 @@
             this.groupBox6.TabStop = false;
             this.groupBox6.Text = "Item Log";
             // 
+            // chkShowDirectionToItem
+            // 
+            this.chkShowDirectionToItem.AutoSize = true;
+            this.chkShowDirectionToItem.Location = new System.Drawing.Point(196, 65);
+            this.chkShowDirectionToItem.Name = "chkShowDirectionToItem";
+            this.chkShowDirectionToItem.Size = new System.Drawing.Size(137, 17);
+            this.chkShowDirectionToItem.TabIndex = 42;
+            this.chkShowDirectionToItem.Text = "Show Direction To Item";
+            this.chkShowDirectionToItem.UseVisualStyleBackColor = true;
+            this.chkShowDirectionToItem.CheckedChanged += new System.EventHandler(this.chkShowDirectionToItem_CheckedChanged);
+            // 
             // chkShowDistanceToItem
             // 
             this.chkShowDistanceToItem.AutoSize = true;
-            this.chkShowDistanceToItem.Location = new System.Drawing.Point(191, 42);
+            this.chkShowDistanceToItem.Location = new System.Drawing.Point(196, 42);
             this.chkShowDistanceToItem.Name = "chkShowDistanceToItem";
             this.chkShowDistanceToItem.Size = new System.Drawing.Size(182, 17);
             this.chkShowDistanceToItem.TabIndex = 41;
@@ -1543,7 +1578,7 @@
             this.lblSoundVolumeValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblSoundVolumeValue.AutoSize = true;
             this.lblSoundVolumeValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblSoundVolumeValue.Location = new System.Drawing.Point(345, 187);
+            this.lblSoundVolumeValue.Location = new System.Drawing.Point(346, 162);
             this.lblSoundVolumeValue.Name = "lblSoundVolumeValue";
             this.lblSoundVolumeValue.Size = new System.Drawing.Size(25, 13);
             this.lblSoundVolumeValue.TabIndex = 29;
@@ -1555,7 +1590,7 @@
             this.lblItemDisplayForSecondsValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblItemDisplayForSecondsValue.AutoSize = true;
             this.lblItemDisplayForSecondsValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblItemDisplayForSecondsValue.Location = new System.Drawing.Point(345, 228);
+            this.lblItemDisplayForSecondsValue.Location = new System.Drawing.Point(346, 203);
             this.lblItemDisplayForSecondsValue.Name = "lblItemDisplayForSecondsValue";
             this.lblItemDisplayForSecondsValue.Size = new System.Drawing.Size(33, 13);
             this.lblItemDisplayForSecondsValue.TabIndex = 25;
@@ -1565,7 +1600,7 @@
             // chkLogTextShadow
             // 
             this.chkLogTextShadow.AutoSize = true;
-            this.chkLogTextShadow.Location = new System.Drawing.Point(127, 270);
+            this.chkLogTextShadow.Location = new System.Drawing.Point(11, 271);
             this.chkLogTextShadow.Name = "chkLogTextShadow";
             this.chkLogTextShadow.Size = new System.Drawing.Size(89, 17);
             this.chkLogTextShadow.TabIndex = 31;
@@ -1578,7 +1613,7 @@
             this.btnClearLogFont.FlatAppearance.BorderSize = 0;
             this.btnClearLogFont.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnClearLogFont.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
-            this.btnClearLogFont.Location = new System.Drawing.Point(86, 268);
+            this.btnClearLogFont.Location = new System.Drawing.Point(86, 236);
             this.btnClearLogFont.Name = "btnClearLogFont";
             this.btnClearLogFont.Size = new System.Drawing.Size(23, 23);
             this.btnClearLogFont.TabIndex = 30;
@@ -1593,7 +1628,7 @@
             this.itemDisplayForSeconds.AutoSize = false;
             this.itemDisplayForSeconds.BackColor = System.Drawing.Color.White;
             this.itemDisplayForSeconds.LargeChange = 1;
-            this.itemDisplayForSeconds.Location = new System.Drawing.Point(85, 228);
+            this.itemDisplayForSeconds.Location = new System.Drawing.Point(86, 203);
             this.itemDisplayForSeconds.Maximum = 24;
             this.itemDisplayForSeconds.Minimum = 1;
             this.itemDisplayForSeconds.Name = "itemDisplayForSeconds";
@@ -1627,7 +1662,7 @@
             // btnLogFont
             // 
             this.btnLogFont.BackColor = System.Drawing.Color.Transparent;
-            this.btnLogFont.Location = new System.Drawing.Point(11, 268);
+            this.btnLogFont.Location = new System.Drawing.Point(11, 236);
             this.btnLogFont.Name = "btnLogFont";
             this.btnLogFont.Size = new System.Drawing.Size(75, 23);
             this.btnLogFont.TabIndex = 22;
@@ -1638,7 +1673,7 @@
             // lblItemLogPosition
             // 
             this.lblItemLogPosition.AutoSize = true;
-            this.lblItemLogPosition.Location = new System.Drawing.Point(188, 23);
+            this.lblItemLogPosition.Location = new System.Drawing.Point(192, 20);
             this.lblItemLogPosition.Name = "lblItemLogPosition";
             this.lblItemLogPosition.Size = new System.Drawing.Size(44, 13);
             this.lblItemLogPosition.TabIndex = 37;
@@ -1652,7 +1687,7 @@
             this.soundVolume.BackColor = System.Drawing.Color.White;
             this.soundVolume.Cursor = System.Windows.Forms.Cursors.Default;
             this.soundVolume.LargeChange = 1;
-            this.soundVolume.Location = new System.Drawing.Point(85, 187);
+            this.soundVolume.Location = new System.Drawing.Point(86, 162);
             this.soundVolume.Maximum = 20;
             this.soundVolume.Name = "soundVolume";
             this.soundVolume.Size = new System.Drawing.Size(254, 27);
@@ -1664,7 +1699,7 @@
             // chkPlaySound
             // 
             this.chkPlaySound.AutoSize = true;
-            this.chkPlaySound.Location = new System.Drawing.Point(11, 127);
+            this.chkPlaySound.Location = new System.Drawing.Point(11, 130);
             this.chkPlaySound.Name = "chkPlaySound";
             this.chkPlaySound.Size = new System.Drawing.Size(123, 17);
             this.chkPlaySound.TabIndex = 3;
@@ -1675,7 +1710,7 @@
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(8, 187);
+            this.label10.Location = new System.Drawing.Point(8, 162);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(42, 13);
             this.label10.TabIndex = 27;
@@ -1684,7 +1719,7 @@
             // label17
             // 
             this.label17.AutoSize = true;
-            this.label17.Location = new System.Drawing.Point(8, 150);
+            this.label17.Location = new System.Drawing.Point(193, 91);
             this.label17.Name = "label17";
             this.label17.Size = new System.Drawing.Size(57, 13);
             this.label17.TabIndex = 4;
@@ -1693,7 +1728,7 @@
             // label18
             // 
             this.label18.AutoSize = true;
-            this.label18.Location = new System.Drawing.Point(8, 228);
+            this.label18.Location = new System.Drawing.Point(8, 203);
             this.label18.Name = "label18";
             this.label18.Size = new System.Drawing.Size(75, 13);
             this.label18.TabIndex = 6;
@@ -1703,9 +1738,9 @@
             // 
             this.txtSoundFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtSoundFile.Location = new System.Drawing.Point(85, 147);
+            this.txtSoundFile.Location = new System.Drawing.Point(256, 88);
             this.txtSoundFile.Name = "txtSoundFile";
-            this.txtSoundFile.Size = new System.Drawing.Size(293, 20);
+            this.txtSoundFile.Size = new System.Drawing.Size(122, 20);
             this.txtSoundFile.TabIndex = 5;
             this.txtSoundFile.TextChanged += new System.EventHandler(this.txtSoundFile_TextChanged);
             this.txtSoundFile.LostFocus += new System.EventHandler(this.txtSoundFile_LostFocus);
@@ -1716,7 +1751,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cboItemLogPosition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboItemLogPosition.FormattingEnabled = true;
-            this.cboItemLogPosition.Location = new System.Drawing.Point(238, 17);
+            this.cboItemLogPosition.Location = new System.Drawing.Point(242, 17);
             this.cboItemLogPosition.Name = "cboItemLogPosition";
             this.cboItemLogPosition.Size = new System.Drawing.Size(140, 21);
             this.cboItemLogPosition.TabIndex = 38;
@@ -1726,9 +1761,9 @@
             // 
             this.txtFilterFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtFilterFile.Location = new System.Drawing.Point(85, 88);
+            this.txtFilterFile.Location = new System.Drawing.Point(62, 88);
             this.txtFilterFile.Name = "txtFilterFile";
-            this.txtFilterFile.Size = new System.Drawing.Size(293, 20);
+            this.txtFilterFile.Size = new System.Drawing.Size(122, 20);
             this.txtFilterFile.TabIndex = 2;
             this.txtFilterFile.TextChanged += new System.EventHandler(this.txtFilterFile_TextChanged);
             // 
@@ -1737,7 +1772,7 @@
             this.label20.AutoSize = true;
             this.label20.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F);
             this.label20.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.label20.Location = new System.Drawing.Point(82, 170);
+            this.label20.Location = new System.Drawing.Point(255, 111);
             this.label20.Name = "label20";
             this.label20.Size = new System.Drawing.Size(115, 13);
             this.label20.TabIndex = 25;
@@ -1759,7 +1794,7 @@
             this.label21.AutoSize = true;
             this.label21.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F);
             this.label21.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.label21.Location = new System.Drawing.Point(82, 111);
+            this.label21.Location = new System.Drawing.Point(59, 111);
             this.label21.Name = "label21";
             this.label21.Size = new System.Drawing.Size(80, 13);
             this.label21.TabIndex = 26;
@@ -2063,16 +2098,149 @@
             this.chkDPIAware.UseVisualStyleBackColor = true;
             this.chkDPIAware.CheckedChanged += new System.EventHandler(this.chkDPIAware_CheckedChanged);
             // 
-            // chkShowDirectionToItem
+            // btnClearMagicColor
             // 
-            this.chkShowDirectionToItem.AutoSize = true;
-            this.chkShowDirectionToItem.Location = new System.Drawing.Point(191, 65);
-            this.chkShowDirectionToItem.Name = "chkShowDirectionToItem";
-            this.chkShowDirectionToItem.Size = new System.Drawing.Size(137, 17);
-            this.chkShowDirectionToItem.TabIndex = 42;
-            this.chkShowDirectionToItem.Text = "Show Direction To Item";
-            this.chkShowDirectionToItem.UseVisualStyleBackColor = true;
-            this.chkShowDirectionToItem.CheckedChanged += new System.EventHandler(this.chkShowDirectionToItem_CheckedChanged);
+            this.btnClearMagicColor.FlatAppearance.BorderSize = 0;
+            this.btnClearMagicColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearMagicColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearMagicColor.Location = new System.Drawing.Point(274, 238);
+            this.btnClearMagicColor.Name = "btnClearMagicColor";
+            this.btnClearMagicColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearMagicColor.TabIndex = 43;
+            this.btnClearMagicColor.Text = "X";
+            this.btnClearMagicColor.UseVisualStyleBackColor = true;
+            this.btnClearMagicColor.Click += new System.EventHandler(this.btnClearMagicColor_Click);
+            // 
+            // btnMagicColor
+            // 
+            this.btnMagicColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnMagicColor.Location = new System.Drawing.Point(217, 238);
+            this.btnMagicColor.Name = "btnMagicColor";
+            this.btnMagicColor.Size = new System.Drawing.Size(56, 23);
+            this.btnMagicColor.TabIndex = 44;
+            this.btnMagicColor.Text = "Magic";
+            this.btnMagicColor.UseVisualStyleBackColor = true;
+            this.btnMagicColor.Click += new System.EventHandler(this.btnMagicColor_Click);
+            // 
+            // btnClearRareColor
+            // 
+            this.btnClearRareColor.FlatAppearance.BorderSize = 0;
+            this.btnClearRareColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearRareColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearRareColor.Location = new System.Drawing.Point(360, 238);
+            this.btnClearRareColor.Name = "btnClearRareColor";
+            this.btnClearRareColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearRareColor.TabIndex = 45;
+            this.btnClearRareColor.Text = "X";
+            this.btnClearRareColor.UseVisualStyleBackColor = true;
+            this.btnClearRareColor.Click += new System.EventHandler(this.btnClearRareColor_Click);
+            // 
+            // btnRareColor
+            // 
+            this.btnRareColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnRareColor.Location = new System.Drawing.Point(303, 238);
+            this.btnRareColor.Name = "btnRareColor";
+            this.btnRareColor.Size = new System.Drawing.Size(56, 23);
+            this.btnRareColor.TabIndex = 46;
+            this.btnRareColor.Text = "Rare";
+            this.btnRareColor.UseVisualStyleBackColor = true;
+            this.btnRareColor.Click += new System.EventHandler(this.btnRareColor_Click);
+            // 
+            // btnClearCraftedColor
+            // 
+            this.btnClearCraftedColor.FlatAppearance.BorderSize = 0;
+            this.btnClearCraftedColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearCraftedColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearCraftedColor.Location = new System.Drawing.Point(360, 271);
+            this.btnClearCraftedColor.Name = "btnClearCraftedColor";
+            this.btnClearCraftedColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearCraftedColor.TabIndex = 47;
+            this.btnClearCraftedColor.Text = "X";
+            this.btnClearCraftedColor.UseVisualStyleBackColor = true;
+            this.btnClearCraftedColor.Click += new System.EventHandler(this.btnClearCraftedColor_Click);
+            // 
+            // btnCraftedColor
+            // 
+            this.btnCraftedColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnCraftedColor.Location = new System.Drawing.Point(303, 271);
+            this.btnCraftedColor.Name = "btnCraftedColor";
+            this.btnCraftedColor.Size = new System.Drawing.Size(56, 23);
+            this.btnCraftedColor.TabIndex = 48;
+            this.btnCraftedColor.Text = "Crafted";
+            this.btnCraftedColor.UseVisualStyleBackColor = true;
+            this.btnCraftedColor.Click += new System.EventHandler(this.btnCraftedColor_Click);
+            // 
+            // btnClearSetColor
+            // 
+            this.btnClearSetColor.FlatAppearance.BorderSize = 0;
+            this.btnClearSetColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearSetColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearSetColor.Location = new System.Drawing.Point(188, 271);
+            this.btnClearSetColor.Name = "btnClearSetColor";
+            this.btnClearSetColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearSetColor.TabIndex = 49;
+            this.btnClearSetColor.Text = "X";
+            this.btnClearSetColor.UseVisualStyleBackColor = true;
+            this.btnClearSetColor.Click += new System.EventHandler(this.btnClearSetColor_Click);
+            // 
+            // btnSetColor
+            // 
+            this.btnSetColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnSetColor.Location = new System.Drawing.Point(131, 271);
+            this.btnSetColor.Name = "btnSetColor";
+            this.btnSetColor.Size = new System.Drawing.Size(56, 23);
+            this.btnSetColor.TabIndex = 50;
+            this.btnSetColor.Text = "Set";
+            this.btnSetColor.UseVisualStyleBackColor = true;
+            this.btnSetColor.Click += new System.EventHandler(this.btnSetColor_Click);
+            // 
+            // btnClearUniqueColor
+            // 
+            this.btnClearUniqueColor.FlatAppearance.BorderSize = 0;
+            this.btnClearUniqueColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearUniqueColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearUniqueColor.Location = new System.Drawing.Point(274, 271);
+            this.btnClearUniqueColor.Name = "btnClearUniqueColor";
+            this.btnClearUniqueColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearUniqueColor.TabIndex = 51;
+            this.btnClearUniqueColor.Text = "X";
+            this.btnClearUniqueColor.UseVisualStyleBackColor = true;
+            this.btnClearUniqueColor.Click += new System.EventHandler(this.btnClearUniqueColor_Click);
+            // 
+            // btnUniqueColor
+            // 
+            this.btnUniqueColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnUniqueColor.Location = new System.Drawing.Point(217, 271);
+            this.btnUniqueColor.Name = "btnUniqueColor";
+            this.btnUniqueColor.Size = new System.Drawing.Size(56, 23);
+            this.btnUniqueColor.TabIndex = 52;
+            this.btnUniqueColor.Text = "Unique";
+            this.btnUniqueColor.UseVisualStyleBackColor = true;
+            this.btnUniqueColor.Click += new System.EventHandler(this.btnUniqueColor_Click);
+            // 
+            // btnClearSuperiorColor
+            // 
+            this.btnClearSuperiorColor.FlatAppearance.BorderSize = 0;
+            this.btnClearSuperiorColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearSuperiorColor.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
+            this.btnClearSuperiorColor.Location = new System.Drawing.Point(188, 238);
+            this.btnClearSuperiorColor.Name = "btnClearSuperiorColor";
+            this.btnClearSuperiorColor.Size = new System.Drawing.Size(23, 23);
+            this.btnClearSuperiorColor.TabIndex = 53;
+            this.btnClearSuperiorColor.Text = "X";
+            this.btnClearSuperiorColor.UseVisualStyleBackColor = true;
+            this.btnClearSuperiorColor.Click += new System.EventHandler(this.btnClearSuperiorColor_Click);
+            // 
+            // btnSuperiorColor
+            // 
+            this.btnSuperiorColor.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnSuperiorColor.Location = new System.Drawing.Point(131, 238);
+            this.btnSuperiorColor.Name = "btnSuperiorColor";
+            this.btnSuperiorColor.Size = new System.Drawing.Size(56, 23);
+            this.btnSuperiorColor.TabIndex = 54;
+            this.btnSuperiorColor.Text = "Superior";
+            this.btnSuperiorColor.UseVisualStyleBackColor = true;
+            this.btnSuperiorColor.Click += new System.EventHandler(this.btnSuperiorColor_Click);
             // 
             // ConfigEditor
             // 
@@ -2295,5 +2463,17 @@
         private System.Windows.Forms.TextBox txtAuthorizedWindowTitle;
         private System.Windows.Forms.CheckBox chkShowDistanceToItem;
         private System.Windows.Forms.CheckBox chkShowDirectionToItem;
+        private System.Windows.Forms.Button btnClearMagicColor;
+        private System.Windows.Forms.Button btnMagicColor;
+        private System.Windows.Forms.Button btnClearRareColor;
+        private System.Windows.Forms.Button btnRareColor;
+        private System.Windows.Forms.Button btnClearUniqueColor;
+        private System.Windows.Forms.Button btnUniqueColor;
+        private System.Windows.Forms.Button btnClearSetColor;
+        private System.Windows.Forms.Button btnSetColor;
+        private System.Windows.Forms.Button btnClearCraftedColor;
+        private System.Windows.Forms.Button btnCraftedColor;
+        private System.Windows.Forms.Button btnClearSuperiorColor;
+        private System.Windows.Forms.Button btnSuperiorColor;
     }
 }

--- a/Forms/ConfigEditor.Designer.cs
+++ b/Forms/ConfigEditor.Designer.cs
@@ -51,6 +51,7 @@
             this.chkShowGameTimer = new System.Windows.Forms.CheckBox();
             this.chkShowArea = new System.Windows.Forms.CheckBox();
             this.chkShowGameName = new System.Windows.Forms.CheckBox();
+            this.chkShowBossKillCount = new System.Windows.Forms.CheckBox();
             this.tabPage1 = new System.Windows.Forms.TabPage();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.chkMonsterHealthBar = new System.Windows.Forms.CheckBox();
@@ -364,6 +365,7 @@
             this.grpGameInfo.Controls.Add(this.chkShowGameTimer);
             this.grpGameInfo.Controls.Add(this.chkShowArea);
             this.grpGameInfo.Controls.Add(this.chkShowGameName);
+            this.grpGameInfo.Controls.Add(this.chkShowBossKillCount);
             this.grpGameInfo.Location = new System.Drawing.Point(11, 9);
             this.grpGameInfo.Name = "grpGameInfo";
             this.grpGameInfo.Size = new System.Drawing.Size(388, 144);
@@ -376,7 +378,7 @@
             this.chkShowAreaLevel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.chkShowAreaLevel.AutoSize = true;
-            this.chkShowAreaLevel.Location = new System.Drawing.Point(192, 65);
+            this.chkShowAreaLevel.Location = new System.Drawing.Point(150, 65);
             this.chkShowAreaLevel.Name = "chkShowAreaLevel";
             this.chkShowAreaLevel.Size = new System.Drawing.Size(77, 17);
             this.chkShowAreaLevel.TabIndex = 39;
@@ -423,7 +425,7 @@
             this.chkShowOverlayFPS.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.chkShowOverlayFPS.AutoSize = true;
-            this.chkShowOverlayFPS.Location = new System.Drawing.Point(192, 88);
+            this.chkShowOverlayFPS.Location = new System.Drawing.Point(150, 88);
             this.chkShowOverlayFPS.Name = "chkShowOverlayFPS";
             this.chkShowOverlayFPS.Size = new System.Drawing.Size(85, 17);
             this.chkShowOverlayFPS.TabIndex = 2;
@@ -471,7 +473,7 @@
             this.chkShowAreaTimer.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.chkShowAreaTimer.AutoSize = true;
-            this.chkShowAreaTimer.Location = new System.Drawing.Point(192, 42);
+            this.chkShowAreaTimer.Location = new System.Drawing.Point(150, 42);
             this.chkShowAreaTimer.Name = "chkShowAreaTimer";
             this.chkShowAreaTimer.Size = new System.Drawing.Size(77, 17);
             this.chkShowAreaTimer.TabIndex = 41;
@@ -495,7 +497,7 @@
             this.chkShowArea.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.chkShowArea.AutoSize = true;
-            this.chkShowArea.Location = new System.Drawing.Point(192, 19);
+            this.chkShowArea.Location = new System.Drawing.Point(150, 19);
             this.chkShowArea.Name = "chkShowArea";
             this.chkShowArea.Size = new System.Drawing.Size(48, 17);
             this.chkShowArea.TabIndex = 16;
@@ -513,6 +515,17 @@
             this.chkShowGameName.Text = "Game Name && Pass";
             this.chkShowGameName.UseVisualStyleBackColor = true;
             this.chkShowGameName.CheckedChanged += new System.EventHandler(this.chkShowGameName_CheckedChanged);
+            // 
+            // chkShowBossKillCount
+            // 
+            this.chkShowBossKillCount.AutoSize = true;
+            this.chkShowBossKillCount.Location = new System.Drawing.Point(210, 19);
+            this.chkShowBossKillCount.Name = "chkShowBossKillCount";
+            this.chkShowBossKillCount.Size = new System.Drawing.Size(120, 17);
+            this.chkShowBossKillCount.TabIndex = 38;
+            this.chkShowBossKillCount.Text = "Boss Kill Count";
+            this.chkShowBossKillCount.UseVisualStyleBackColor = true;
+            this.chkShowBossKillCount.CheckedChanged += new System.EventHandler(this.chkShowBossKillCount_CheckedChanged);
             // 
             // tabPage1
             // 
@@ -1869,7 +1882,7 @@
             // lblItemLogPosition
             // 
             this.lblItemLogPosition.AutoSize = true;
-            this.lblItemLogPosition.Location = new System.Drawing.Point(192, 20);
+            this.lblItemLogPosition.Location = new System.Drawing.Point(150, 20);
             this.lblItemLogPosition.Name = "lblItemLogPosition";
             this.lblItemLogPosition.Size = new System.Drawing.Size(44, 13);
             this.lblItemLogPosition.TabIndex = 37;
@@ -2507,6 +2520,7 @@
         private System.Windows.Forms.CheckBox chkPotionBelt;
         private System.Windows.Forms.CheckBox chkShowAreaTimer;
         private System.Windows.Forms.CheckBox chkShowGameTimer;
+        private System.Windows.Forms.CheckBox chkShowBossKillCount;
         private System.Windows.Forms.TextBox txtHideMapKey;
         private System.Windows.Forms.Label lblHideMapKey;
         private System.Windows.Forms.GroupBox groupBox8;

--- a/Forms/ConfigEditor.cs
+++ b/Forms/ConfigEditor.cs
@@ -79,6 +79,10 @@ namespace MapAssist
 
             buffSize.Value = (int)Math.Round(MapAssistConfiguration.Loaded.RenderingConfiguration.BuffSize * 10d);
             lblBuffSizeValue.Text = MapAssistConfiguration.Loaded.RenderingConfiguration.BuffSize.ToString();
+            chkBuffs.Checked = MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarBuffs;
+            chkAuras.Checked = MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarAuras;
+            chkPassives.Checked = MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarPassives;
+            chkDebuffs.Checked = MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarDebuffs;
             chkAlertLowerRes.Checked = MapAssistConfiguration.Loaded.RenderingConfiguration.BuffAlertLowRes;
             cboBuffPosition.SelectedIndex = cboBuffPosition.FindStringExact(MapAssistConfiguration.Loaded.RenderingConfiguration.BuffPosition.ToString().ToProperCase());
             cboMapLinesMode.SelectedIndex = cboMapLinesMode.FindStringExact(MapAssistConfiguration.Loaded.RenderingConfiguration.LinesMode.ToString().ToProperCase());
@@ -269,6 +273,26 @@ namespace MapAssist
                 MapAssistConfiguration.Loaded.RenderingConfiguration.BuffSize = 0;
             }
             lblBuffSizeValue.Text = MapAssistConfiguration.Loaded.RenderingConfiguration.BuffSize.ToString();
+        }
+
+        private void chkBuffs_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarBuffs = chkBuffs.Checked;
+        }
+
+        private void chkAuras_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarAuras = chkAuras.Checked;
+        }
+
+        private void chkPassives_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarPassives = chkPassives.Checked;
+        }
+
+        private void chkDebuffs_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarDebuffs = chkDebuffs.Checked;
         }
 
         private void chkAlertLowerRes_CheckedChanged(object sender, EventArgs e)

--- a/Forms/ConfigEditor.cs
+++ b/Forms/ConfigEditor.cs
@@ -130,12 +130,36 @@ namespace MapAssist
                 MapAssistConfiguration.Loaded.ItemLog.LabelFontSize != MapAssistConfiguration.Default.ItemLog.LabelFontSize;
             chkLogTextShadow.Checked = MapAssistConfiguration.Loaded.ItemLog.LabelTextShadow;
 
+            btnSuperiorColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.SuperiorColor;
+            btnSuperiorColor.ForeColor = ContrastTextColor(btnSuperiorColor.BackColor);
+            btnClearSuperiorColor.Visible = MapAssistConfiguration.Loaded.ItemLog.SuperiorColor != MapAssistConfiguration.Default.ItemLog.SuperiorColor;
+
+            btnMagicColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.MagicColor;
+            btnMagicColor.ForeColor = ContrastTextColor(btnMagicColor.BackColor);
+            btnClearMagicColor.Visible = MapAssistConfiguration.Loaded.ItemLog.MagicColor != MapAssistConfiguration.Default.ItemLog.MagicColor;
+
+            btnRareColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.RareColor;
+            btnRareColor.ForeColor = ContrastTextColor(btnRareColor.BackColor);
+            btnClearRareColor.Visible = MapAssistConfiguration.Loaded.ItemLog.RareColor != MapAssistConfiguration.Default.ItemLog.RareColor;
+
+            btnSetColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.SetColor;
+            btnSetColor.ForeColor = ContrastTextColor(btnSetColor.BackColor);
+            btnClearSetColor.Visible = MapAssistConfiguration.Loaded.ItemLog.SetColor != MapAssistConfiguration.Default.ItemLog.SetColor;
+
+            btnUniqueColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.UniqueColor;
+            btnUniqueColor.ForeColor = ContrastTextColor(btnUniqueColor.BackColor);
+            btnClearUniqueColor.Visible = MapAssistConfiguration.Loaded.ItemLog.UniqueColor != MapAssistConfiguration.Default.ItemLog.UniqueColor;
+
+            btnCraftedColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.CraftedColor;
+            btnCraftedColor.ForeColor = ContrastTextColor(btnCraftedColor.BackColor);
+            btnClearCraftedColor.Visible = MapAssistConfiguration.Loaded.ItemLog.CraftedColor != MapAssistConfiguration.Default.ItemLog.CraftedColor;
+
             if (MapAssistConfiguration.Loaded.MapColorConfiguration.Walkable != null)
             {
-                var walkableColor = (Color)MapAssistConfiguration.Loaded.MapColorConfiguration.Walkable;
-                btnWalkableColor.BackColor = walkableColor;
-                btnWalkableColor.ForeColor = ContrastTextColor(btnWalkableColor.BackColor);
-                btnClearWalkableColor.Visible = walkableColor.A > 0;
+                var color = (Color)MapAssistConfiguration.Loaded.MapColorConfiguration.Walkable;
+                btnWalkableColor.BackColor = color;
+                btnWalkableColor.ForeColor = ContrastTextColor(color);
+                btnClearWalkableColor.Visible = color.A > 0;
             }
             else
             {
@@ -144,10 +168,10 @@ namespace MapAssist
 
             if (MapAssistConfiguration.Loaded.MapColorConfiguration.Border != null)
             {
-                var borderColor = (Color)MapAssistConfiguration.Loaded.MapColorConfiguration.Border;
-                btnBorderColor.BackColor = borderColor;
-                btnBorderColor.ForeColor = ContrastTextColor(btnBorderColor.BackColor);
-                btnClearBorderColor.Visible = borderColor.A > 0;
+                var color = (Color)MapAssistConfiguration.Loaded.MapColorConfiguration.Border;
+                btnBorderColor.BackColor = color;
+                btnBorderColor.ForeColor = ContrastTextColor(color);
+                btnClearBorderColor.Visible = color.A > 0;
             }
             else
             {
@@ -752,6 +776,144 @@ namespace MapAssist
         private void chkLogTextShadow_CheckedChanged(object sender, EventArgs e)
         {
             MapAssistConfiguration.Loaded.ItemLog.LabelTextShadow = chkLogTextShadow.Checked;
+        }
+
+        private void btnSuperiorColor_Click(object sender, EventArgs e)
+        {
+            var colorDlg = new ColorDialog();
+            if (colorDlg.ShowDialog() == DialogResult.OK)
+            {
+                MapAssistConfiguration.Loaded.ItemLog.SuperiorColor = colorDlg.Color;
+                btnSuperiorColor.BackColor = colorDlg.Color;
+                btnSuperiorColor.ForeColor = ContrastTextColor(btnSuperiorColor.BackColor);
+
+                btnClearSuperiorColor.Visible = true;
+            }
+        }
+
+        private void btnMagicColor_Click(object sender, EventArgs e)
+        {
+            var colorDlg = new ColorDialog();
+            if (colorDlg.ShowDialog() == DialogResult.OK)
+            {
+                MapAssistConfiguration.Loaded.ItemLog.MagicColor = colorDlg.Color;
+                btnMagicColor.BackColor = colorDlg.Color;
+                btnMagicColor.ForeColor = ContrastTextColor(btnMagicColor.BackColor);
+
+                btnClearMagicColor.Visible = true;
+            }
+        }
+
+        private void btnRareColor_Click(object sender, EventArgs e)
+        {
+            var colorDlg = new ColorDialog();
+            if (colorDlg.ShowDialog() == DialogResult.OK)
+            {
+                MapAssistConfiguration.Loaded.ItemLog.RareColor = colorDlg.Color;
+                btnRareColor.BackColor = colorDlg.Color;
+                btnRareColor.ForeColor = ContrastTextColor(btnRareColor.BackColor);
+
+                btnClearRareColor.Visible = true;
+            }
+        }
+
+        private void btnSetColor_Click(object sender, EventArgs e)
+        {
+            var colorDlg = new ColorDialog();
+            if (colorDlg.ShowDialog() == DialogResult.OK)
+            {
+                MapAssistConfiguration.Loaded.ItemLog.SetColor = colorDlg.Color;
+                btnSetColor.BackColor = colorDlg.Color;
+                btnSetColor.ForeColor = ContrastTextColor(btnSetColor.BackColor);
+
+                btnClearSetColor.Visible = true;
+            }
+        }
+
+        private void btnUniqueColor_Click(object sender, EventArgs e)
+        {
+            var colorDlg = new ColorDialog();
+            if (colorDlg.ShowDialog() == DialogResult.OK)
+            {
+                MapAssistConfiguration.Loaded.ItemLog.UniqueColor = colorDlg.Color;
+                btnUniqueColor.BackColor = colorDlg.Color;
+                btnUniqueColor.ForeColor = ContrastTextColor(btnUniqueColor.BackColor);
+
+                btnClearUniqueColor.Visible = true;
+            }
+        }
+
+        private void btnCraftedColor_Click(object sender, EventArgs e)
+        {
+            var colorDlg = new ColorDialog();
+            if (colorDlg.ShowDialog() == DialogResult.OK)
+            {
+                MapAssistConfiguration.Loaded.ItemLog.CraftedColor = colorDlg.Color;
+                btnCraftedColor.BackColor = colorDlg.Color;
+                btnCraftedColor.ForeColor = ContrastTextColor(btnCraftedColor.BackColor);
+
+                btnClearCraftedColor.Visible = true;
+            }
+        }
+
+        private void btnClearSuperiorColor_Click(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.ItemLog.SuperiorColor = MapAssistConfiguration.Default.ItemLog.SuperiorColor;
+
+            btnSuperiorColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.SuperiorColor;
+            btnSuperiorColor.ForeColor = ContrastTextColor(btnSuperiorColor.BackColor);
+
+            btnClearSuperiorColor.Visible = false;
+        }
+
+        private void btnClearMagicColor_Click(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.ItemLog.MagicColor = MapAssistConfiguration.Default.ItemLog.MagicColor;
+
+            btnMagicColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.MagicColor;
+            btnMagicColor.ForeColor = ContrastTextColor(btnMagicColor.BackColor);
+
+            btnClearMagicColor.Visible = false;
+        }
+
+        private void btnClearRareColor_Click(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.ItemLog.RareColor = MapAssistConfiguration.Default.ItemLog.RareColor;
+
+            btnRareColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.RareColor;
+            btnRareColor.ForeColor = ContrastTextColor(btnRareColor.BackColor);
+
+            btnClearRareColor.Visible = false;
+        }
+
+        private void btnClearSetColor_Click(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.ItemLog.SetColor = MapAssistConfiguration.Default.ItemLog.SetColor;
+
+            btnSetColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.SetColor;
+            btnSetColor.ForeColor = ContrastTextColor(btnSetColor.BackColor);
+
+            btnClearSetColor.Visible = false;
+        }
+
+        private void btnClearUniqueColor_Click(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.ItemLog.UniqueColor = MapAssistConfiguration.Default.ItemLog.UniqueColor;
+
+            btnUniqueColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.UniqueColor;
+            btnUniqueColor.ForeColor = ContrastTextColor(btnUniqueColor.BackColor);
+
+            btnClearUniqueColor.Visible = false;
+        }
+
+        private void btnClearCraftedColor_Click(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.ItemLog.CraftedColor = MapAssistConfiguration.Default.ItemLog.CraftedColor;
+
+            btnCraftedColor.BackColor = MapAssistConfiguration.Loaded.ItemLog.CraftedColor;
+            btnCraftedColor.ForeColor = ContrastTextColor(btnCraftedColor.BackColor);
+
+            btnClearCraftedColor.Visible = false;
         }
 
         private void txtToggleMapKey_TextChanged(object sender, EventArgs e)

--- a/Forms/ConfigEditor.cs
+++ b/Forms/ConfigEditor.cs
@@ -99,6 +99,7 @@ namespace MapAssist
             chkShowGameName.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowGameName;
             chkShowGameTimer.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowGameTimer;
             chkShowAreaTimer.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowAreaTimer;
+            chkShowBossKillCount.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowBossKillCount;
             chkShowArea.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowArea;
             chkShowAreaLevel.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowAreaLevel;
             chkShowDifficulty.Checked = MapAssistConfiguration.Loaded.GameInfo.ShowDifficulty;
@@ -383,6 +384,11 @@ namespace MapAssist
         private void chkShowGameName_CheckedChanged(object sender, EventArgs e)
         {
             MapAssistConfiguration.Loaded.GameInfo.ShowGameName = chkShowGameName.Checked;
+        }
+        
+        private void chkShowBossKillCount_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.GameInfo.ShowBossKillCount = chkShowBossKillCount.Checked;
         }
 
         private void chkShowGameTimer_CheckedChanged(object sender, EventArgs e)

--- a/Helpers/BossKillCountRepository.cs
+++ b/Helpers/BossKillCountRepository.cs
@@ -1,0 +1,127 @@
+﻿using LiteDB;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MapAssist.Helpers
+{
+    public class BossKillCount
+    {
+        public ObjectId Id { get; set; }
+        public uint Andariel { get; set; }
+        public uint Duriel { get; set; }
+        public uint Mephisto { get; set; }
+        public uint Diablo { get; set; }
+        public uint Baal { get; set; }
+    }
+    
+    public class BossKillCountRepository
+    {
+        private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+        private ILiteDatabase db;
+        
+        private static string _dbFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "MapAssist");
+        
+        private static string _dbPath =  Path.Combine(_dbFolder,"bosskillcount.db");
+
+        private BossKillCount _lastFetched { get; set; } = new BossKillCount();
+        
+        private SemaphoreSlim _semaphore { get; }
+
+        public BossKillCountRepository()
+        {
+            if (!Directory.Exists(_dbFolder))
+            {
+                Directory.CreateDirectory(_dbFolder);
+            }
+
+            db = new LiteDatabase(_dbPath);
+            
+            _semaphore = new SemaphoreSlim(1, 1);
+        }
+        
+        public async Task<BossKillCount> Get()
+        {
+            if (_semaphore.CurrentCount == 0)
+            {
+                return _lastFetched;
+            }
+
+            await _semaphore.WaitAsync();
+            try
+            {
+                var collection = db.GetCollection<BossKillCount>("bosskillcount");
+                var result = collection.FindOne(x => true);
+                if (result == null)
+                {
+                    result = new BossKillCount();
+                    collection.Insert(result);
+                }
+
+                _lastFetched = result;
+                return result;
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+
+        //Increment Andariel kill count
+        public void IncrementAndariel()
+        {
+            var collection = db.GetCollection<BossKillCount>("bosskillcount");
+            var result = collection.FindOne(x => true);
+            result.Andariel++;
+            _logger.Info("Andariel killed: " + result.Andariel);
+            collection.Update(result);
+        }
+        
+        //Increment Duriel kill count
+        public void IncrementDuriel()
+        {
+            var collection = db.GetCollection<BossKillCount>("bosskillcount");
+            var result = collection.FindOne(x => true);
+            result.Duriel++;
+            _logger.Info("Duriel killed: " + result.Duriel);
+            collection.Update(result);
+        }
+        
+        //Increment Mephisto kill count
+        public void IncrementMephisto()
+        {
+            var collection = db.GetCollection<BossKillCount>("bosskillcount");
+            var result = collection.FindOne(x => true);
+            result.Mephisto++;
+            _logger.Info("Mephisto killed: " + result.Mephisto);
+            collection.Update(result);
+        }
+        
+        //Increment Diablo kill count
+        public void IncrementDiablo()
+        {
+            var collection = db.GetCollection<BossKillCount>("bosskillcount");
+            var result = collection.FindOne(x => true);
+            result.Diablo++;
+            _logger.Info("Diablo killed: " + result.Diablo);
+            collection.Update(result);
+        }
+        
+        //Increment Baal kill count
+        public void IncrementBaal()
+        {
+            var collection = db.GetCollection<BossKillCount>("bosskillcount");
+            var result = collection.FindOne(x => true);
+            result.Baal++;
+            _logger.Info("Baal killed: " + result.Baal);
+            collection.Update(result);
+        }
+        
+        ~BossKillCountRepository()
+        {
+            db.Dispose();
+        }
+    }
+}

--- a/Helpers/BossStateTracker.cs
+++ b/Helpers/BossStateTracker.cs
@@ -1,0 +1,56 @@
+﻿using MapAssist.Types;
+
+namespace MapAssist.Helpers
+{
+    public class BossStateTracker
+    {
+        private NLog.Logger _log = NLog.LogManager.GetCurrentClassLogger();
+        private UnitMonster _activeBoss;
+        private readonly BossKillCountRepository _bossKillCountRepository;
+
+        public BossStateTracker(BossKillCountRepository bossKillCountRepository)
+        {
+            _bossKillCountRepository = bossKillCountRepository;
+        }
+
+        public void Activate(UnitMonster unitMonster)
+        {
+            if (_activeBoss != null)
+            {
+                return;
+            }
+            
+            _log.Info("Tracking boss {0}", unitMonster);
+            _activeBoss = unitMonster;
+        }
+        
+        public void Clear()
+        {
+            if (_activeBoss == null)
+                return;
+            
+            switch (_activeBoss.Npc)
+            {
+                case Npc.Andariel:
+                    _bossKillCountRepository.IncrementAndariel();
+                    break;
+                case Npc.Duriel:
+                    _bossKillCountRepository.IncrementDuriel();
+                    break;
+                case Npc.Mephisto:
+                    _bossKillCountRepository.IncrementMephisto();
+                    break;
+                case Npc.Diablo:
+                    _bossKillCountRepository.IncrementDiablo();
+                    break;
+                case Npc.BaalCrab:
+                    _bossKillCountRepository.IncrementBaal();
+                    break;
+                default:
+                    _log.Warn("Unknown boss {0} for tracker", _activeBoss);
+                    break;
+            }
+            _activeBoss = null;
+        }
+    }
+}

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -721,10 +721,10 @@ namespace MapAssist.Helpers
             var buffsByColor = new Dictionary<Color, List<Bitmap>>();
             var totalBuffs = 0;
 
-            buffsByColor.Add(States.DebuffColor, new List<Bitmap>());
-            buffsByColor.Add(States.PassiveColor, new List<Bitmap>());
-            buffsByColor.Add(States.AuraColor, new List<Bitmap>());
-            buffsByColor.Add(States.BuffColor, new List<Bitmap>());
+            if (MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarBuffs) buffsByColor.Add(States.BuffColor, new List<Bitmap>());
+            if (MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarAuras) buffsByColor.Add(States.AuraColor, new List<Bitmap>());
+            if (MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarPassives) buffsByColor.Add(States.PassiveColor, new List<Bitmap>());
+            if (MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarDebuffs) buffsByColor.Add(States.DebuffColor, new List<Bitmap>());
 
             var alertLoweredRes = false;
 
@@ -785,14 +785,14 @@ namespace MapAssist.Helpers
 
             if (buffImageScale > 0)
             {
-                var buffIndex = 1;
+                var buffIndex = 0;
                 foreach (var buff in buffsByColor)
                 {
                     for (var i = 0; i < buff.Value.Count; i++)
                     {
                         var buffImg = buff.Value[i];
                         var buffColor = buff.Key;
-                        var drawPoint = new Point((gfx.Width / 2f) - (buffIndex * imgDimensions) - (buffIndex * buffImageScale) - (totalBuffs * buffImageScale / 2f) + (totalBuffs * imgDimensions / 2f) + (totalBuffs * buffImageScale), buffYPos);
+                        var drawPoint = new Point((gfx.Width / 2f) - (totalBuffs * imgDimensions / 2f) + (buffIndex * imgDimensions), buffYPos);
                         DrawBitmap(gfx, buffImg, drawPoint, 1, size: buffImageScale);
 
                         var size = new Point(imgDimensions + buffImageScale, imgDimensions + buffImageScale);

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -197,7 +197,13 @@ namespace MapAssist.Helpers
 
             var drawnPreviousNextAreas = new List<Point>();
 
-            var areasToRender = (new AreaData[] { _areaData }).Concat(_areaData.AdjacentAreas.Values).ToArray();
+            var areasToRender = new AreaData[] { _areaData };
+            if (AreaExtensions.RequiresStitching(_areaData.Area))
+            {
+                areasToRender = areasToRender.Concat(_areaData.AdjacentAreas.Values.Where(area => AreaExtensions.RequiresStitching(area.Area))).ToArray();
+            }
+
+
             foreach (var area in areasToRender)
             {
                 if (area.PointsOfInterest == null) continue;

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -844,72 +844,59 @@ namespace MapAssist.Helpers
         {
             if (!MapAssistConfiguration.Loaded.RenderingConfiguration.MonsterHealthBar) return;
 
-            Func<(UnitMonster, string)> getActiveMonster = () =>
+            (UnitMonster, string)[] getActiveMonsters()
             {
                 var hoveredUnit = _gameData.Monsters.Where(x => x.IsHovered).ToArray();
 
                 var boss = _gameData.Monsters.FirstOrDefault(x => NPC.Bosses.Contains(x.Npc));
-                if (boss != null && (boss.IsHovered || hoveredUnit.Count() == 0)) return (boss, NpcExtensions.Name(boss.Npc));
+                if (boss != null && (boss.IsHovered || hoveredUnit.Count() == 0)) return new[] { (boss, NpcExtensions.Name(boss.Npc)) };
 
-                var monstersAround = new List<(UnitMonster, string)>();
+                var superUniques = _gameData.Monsters.Where(x => x.IsSuperUnique && (x.IsHovered || hoveredUnit.Count() == 0)).Select(x => (x, NpcExtensions.LocalizedName(x.SuperUniqueName))).ToArray();
+                if (superUniques.Count() > 0) return superUniques;
 
-                foreach (var monster in _gameData.Monsters)
-                {
-                    var monsterClass = Encoding.UTF8.GetString(monster.MonsterStats.Name).TrimEnd((char)0);
-                    var monsterName = NPC.SuperUniques.Where(x => x.Value == monsterClass).ToArray();
-
-                    if (monsterName.Length == 1 && (monster.MonsterData.BossLineID > 0 || monster.Npc == Npc.Summoner)) // Summoner seems to be an odd exception
-                    {
-                        monstersAround.Add((monster, NpcExtensions.LocalizedName(monsterName[0].Key)));
-                    }
-                }
-
-                if (monstersAround.Count == 1 && hoveredUnit.Count() == 0) return monstersAround[0];
-                else if (monstersAround.Count == 0) return (null, null);
-
-                var hoveredMonster = monstersAround.Where(x => x.Item1.IsHovered).ToArray();
-                if (hoveredMonster.Length == 1) return hoveredMonster[0];
-
-                return (null, null);
+                return new (UnitMonster, string)[] { };
             };
 
-            var (activeMonster, name) = getActiveMonster();
-            if (activeMonster == null) return;
+            var activeMonsters = getActiveMonsters();
+            if (activeMonsters.Length == 0) return;
 
-            // Health
-            var healthPerc = activeMonster.HealthPercentage;
-            var infoText = $"{name} HP: {healthPerc:P}";
-
-            var barWidth = gfx.Width * 0.3f;
-            var barHeight = gfx.Height * 0.04f;
-            var font = MapAssistConfiguration.Loaded.GameInfo.LabelFont;
-
-            var fontSize = barHeight / 2f;
-            var blackBrush = CreateSolidBrush(gfx, Color.Black, 1);
-            var darkFillBrush = CreateSolidBrush(gfx, Color.FromArgb(66, 0, 125), 1);
-            var lightFillBrush = CreateSolidBrush(gfx, Color.FromArgb(100, 93, 107), 1);
-
-            var center = new Point(gfx.Width / 2, gfx.Height * 0.043f);
-            var barRect = new Rectangle(center.X - barWidth / 2, center.Y - barHeight / 2, center.X + barWidth / 2, center.Y + barHeight / 2);
-            var fillRect = new Rectangle(center.X - barWidth / 2, center.Y - barHeight / 2, center.X - barWidth / 2 + barWidth * healthPerc, center.Y + barHeight / 2);
-
-            gfx.FillRectangle(lightFillBrush, barRect);
-            gfx.FillRectangle(darkFillBrush, fillRect);
-            gfx.DrawRectangle(blackBrush, barRect, 2);
-
-            var infoTextPosition = center.Add(0, gfx.Height * (activeMonster.Immunities.Count() > 0 ? -0.007f : 0));
-
-            DrawText(gfx, infoTextPosition, infoText, font, fontSize, Color.FromArgb(190, 171, 113), false, TextAlign.Center);
-
-            // Immunities
-            var immunityFontSize = gfx.ScaleFontSize(14);
-            var immunitiesDistanceBetween = gfx.ScaleFontSize(10);
-            var immunitiesWidth = activeMonster.Immunities.Select(x => gfx.MeasureString(CreateFont(gfx, font, immunityFontSize), x.ToString()).X).ToArray();
-            var immunitiesTotalWidth = immunitiesWidth.Sum() + immunitiesDistanceBetween * (activeMonster.Immunities.Count() - 1);
-
-            foreach (var (i, immunity) in activeMonster.Immunities.Select((x, i) => (i, x)))
+            foreach (var (i, (activeMonster, name)) in activeMonsters.Select((value, i) => (i, value)))
             {
-                DrawText(gfx, new Point(gfx.Width / 2 - immunitiesTotalWidth / 2 + immunitiesWidth.Take(i).Sum() + immunitiesWidth[i] / 2 + i * immunitiesDistanceBetween, gfx.Height * 0.053f), immunity.ToString(), font, immunityFontSize, ResistColors.ResistColor[immunity], true, TextAlign.Center, 0.8f);
+                // Health
+                var healthPerc = activeMonster.HealthPercentage;
+                var infoText = $"{name} HP: {healthPerc:P}";
+
+                var barWidth = gfx.Width * 0.3f;
+                var barHeight = gfx.Height * 0.04f;
+                var font = MapAssistConfiguration.Loaded.GameInfo.LabelFont;
+
+                var fontSize = barHeight / 2f;
+                var blackBrush = CreateSolidBrush(gfx, Color.Black, 1);
+                var darkFillBrush = CreateSolidBrush(gfx, Color.FromArgb(66, 0, 125), 1);
+                var lightFillBrush = CreateSolidBrush(gfx, Color.FromArgb(100, 93, 107), 1);
+
+                var center = new Point(gfx.Width / 2, gfx.Height * (0.043f + i * 0.05f));
+                var barRect = new Rectangle(center.X - barWidth / 2, center.Y - barHeight / 2, center.X + barWidth / 2, center.Y + barHeight / 2);
+                var fillRect = new Rectangle(center.X - barWidth / 2, center.Y - barHeight / 2, center.X - barWidth / 2 + barWidth * healthPerc, center.Y + barHeight / 2);
+
+                gfx.FillRectangle(lightFillBrush, barRect);
+                gfx.FillRectangle(darkFillBrush, fillRect);
+                gfx.DrawRectangle(blackBrush, barRect, 2);
+
+                var infoTextPosition = center.Add(0, gfx.Height * (activeMonster.Immunities.Count() > 0 ? -0.007f : 0));
+
+                DrawText(gfx, infoTextPosition, infoText, font, fontSize, Color.FromArgb(190, 171, 113), false, TextAlign.Center);
+
+                // Immunities
+                var immunityFontSize = gfx.ScaleFontSize(14);
+                var immunitiesDistanceBetween = gfx.ScaleFontSize(10);
+                var immunitiesWidth = activeMonster.Immunities.Select(x => gfx.MeasureString(CreateFont(gfx, font, immunityFontSize), x.ToString()).X).ToArray();
+                var immunitiesTotalWidth = immunitiesWidth.Sum() + immunitiesDistanceBetween * (activeMonster.Immunities.Count() - 1);
+
+                foreach (var (j, immunity) in activeMonster.Immunities.Select((x, j) => (j, x)))
+                {
+                    DrawText(gfx, new Point(gfx.Width / 2 - immunitiesTotalWidth / 2 + immunitiesWidth.Take(j).Sum() + immunitiesWidth[j] / 2 + j * immunitiesDistanceBetween, center.Y + gfx.Height * 0.01f), immunity.ToString(), font, immunityFontSize, ResistColors.ResistColor[immunity], true, TextAlign.Center, 0.8f);
+                }
             }
         }
 

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -1020,14 +1020,14 @@ namespace MapAssist.Helpers
             var shadowOffset = fontSize * 0.0625f; // 1/16th
 
             // Item Log
-            var itemsToShow = _gameData.ItemLog.Where(item => item != null && !item.ItemLogExpired && item.Color != Color.Empty).ToArray();
+            var itemsToShow = _gameData.ItemLog.Where(item => item != null && !item.ItemLogExpired && item.UnitItem.ItemBaseColor != Color.Empty).ToArray();
             for (var i = 0; i < itemsToShow.Length; i++)
             {
                 var item = itemsToShow[i];
 
                 var font = CreateFont(gfx, MapAssistConfiguration.Loaded.ItemLog.LabelFont, fontSize);
                 var position = anchor.Add(0, i * lineHeight);
-                var brush = CreateSolidBrush(gfx, item.Color, 1);
+                var brush = CreateSolidBrush(gfx, item.UnitItem.ItemBaseColor, 1);
                 var stringSize = gfx.MeasureString(font, item.Text);
 
                 if (MapAssistConfiguration.Loaded.ItemLog.Position == GameInfoPosition.TopRight)
@@ -1082,7 +1082,7 @@ namespace MapAssist.Helpers
 
                     var rendering = new PointOfInterestRendering()
                     {
-                        LineColor = item.Color,
+                        LineColor = item.UnitItem.ItemBaseColor,
                         LineThickness = 2,
                         ArrowHeadSize = 8
                     };

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -912,7 +912,7 @@ namespace MapAssist.Helpers
                     DrawGraphicsEventArgs e, bool errorLoadingAreaData)
         {
             var isTopLeft = MapAssistConfiguration.Loaded.GameInfo.Position == GameInfoPosition.TopLeft;
-            if ((_gameData.MenuPanelOpen & (isTopLeft ? 0x2 : 0x1)) > 0)
+            if (isTopLeft ? _gameData.MenuOpen.IsLeftMenuOpen() : _gameData.MenuOpen.IsRightMenuOpen())
             {
                 return anchor;
             }
@@ -1007,7 +1007,7 @@ namespace MapAssist.Helpers
         public void DrawItemLog(Graphics gfx, Point anchor)
         {
             var isTopLeft = MapAssistConfiguration.Loaded.ItemLog.Position == GameInfoPosition.TopLeft;
-            if ((_gameData.MenuPanelOpen & (isTopLeft ? 0x2 : 0x1)) > 0)
+            if (isTopLeft ? _gameData.MenuOpen.IsLeftMenuOpen() : _gameData.MenuOpen.IsRightMenuOpen())
             {
                 return;
             }

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -234,7 +234,7 @@ namespace MapAssist.Helpers
                         continue;
                     }
 
-                    if (CanDrawMapLines(MapLinesMode.PVE) && poi.RenderingSettings.CanDrawLine() && !area.Area.IsTown())
+                    if (CanDrawMapLines(MapLinesMode.PVE) && poi.RenderingSettings.CanDrawLine() && !area.Area.IsTown() && poi.Area == _areaData.Area)
                     {
                         var fontSize = gfx.ScaleFontSize((float)poi.RenderingSettings.LabelFontSize);
                         var padding = poi.RenderingSettings.CanDrawLabel() ? fontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -854,8 +854,8 @@ namespace MapAssist.Helpers
             {
                 var hoveredUnit = _gameData.Monsters.Where(x => x.IsHovered).ToArray();
 
-                var boss = _gameData.Monsters.FirstOrDefault(x => NPC.Bosses.Contains(x.Npc));
-                if (boss != null && (boss.IsHovered || hoveredUnit.Count() == 0)) return new[] { (boss, NpcExtensions.Name(boss.Npc)) };
+                var bosses = _gameData.Monsters.Where(x => NPC.Bosses.Contains(x.Npc) && (x.IsHovered || hoveredUnit.Count() == 0)).Select(x => (x, NpcExtensions.Name(x.Npc))).ToArray();
+                if (bosses.Count() > 0) return bosses;
 
                 var superUniques = _gameData.Monsters.Where(x => x.IsSuperUnique && (x.IsHovered || hoveredUnit.Count() == 0)).Select(x => (x, NpcExtensions.LocalizedName(x.SuperUniqueName))).ToArray();
                 if (superUniques.Count() > 0) return superUniques;

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -1213,7 +1213,7 @@ namespace MapAssist.Helpers
                 anchor.X + bitmapDX.Size.Width * size,
                 anchor.Y + bitmapDX.Size.Height * size);
 
-            renderTarget.DrawBitmap(bitmapDX, destRect, opacity, BitmapInterpolationMode.Linear, sourceRect);
+            renderTarget.DrawBitmap(bitmapDX, destRect, opacity, BitmapInterpolationMode.NearestNeighbor, sourceRect);
         }
 
         private void DrawIcon(Graphics gfx, IconRendering rendering, Point position,

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -203,7 +203,6 @@ namespace MapAssist.Helpers
                 areasToRender = areasToRender.Concat(_areaData.AdjacentAreas.Values.Where(area => AreaExtensions.RequiresStitching(area.Area))).ToArray();
             }
 
-
             foreach (var area in areasToRender)
             {
                 if (area.PointsOfInterest == null) continue;
@@ -850,14 +849,21 @@ namespace MapAssist.Helpers
         {
             if (!MapAssistConfiguration.Loaded.RenderingConfiguration.MonsterHealthBar) return;
 
+            var areasToRender = new AreaData[] { _areaData };
+            if (AreaExtensions.RequiresStitching(_areaData.Area))
+            {
+                areasToRender = areasToRender.Concat(_areaData.AdjacentAreas.Values.Where(area => AreaExtensions.RequiresStitching(area.Area))).ToArray();
+            }
+
             (UnitMonster, string)[] getActiveMonsters()
             {
+                var areaMonsters = _gameData.Monsters.Where(x => areasToRender.Any(y => y.IncludesPoint(x.Position))).ToArray();
                 var hoveredUnit = _gameData.Monsters.Where(x => x.IsHovered).ToArray();
 
-                var bosses = _gameData.Monsters.Where(x => NPC.Bosses.Contains(x.Npc) && (x.IsHovered || hoveredUnit.Count() == 0)).Select(x => (x, NpcExtensions.Name(x.Npc))).ToArray();
+                var bosses = areaMonsters.Where(x => NPC.Bosses.Contains(x.Npc) && (x.IsHovered || hoveredUnit.Count() == 0)).Select(x => (x, NpcExtensions.Name(x.Npc))).ToArray();
                 if (bosses.Count() > 0) return bosses;
 
-                var superUniques = _gameData.Monsters.Where(x => x.IsSuperUnique && (x.IsHovered || hoveredUnit.Count() == 0)).Select(x => (x, NpcExtensions.LocalizedName(x.SuperUniqueName))).ToArray();
+                var superUniques = areaMonsters.Where(x => x.IsSuperUnique && (x.IsHovered || hoveredUnit.Count() == 0)).Select(x => (x, NpcExtensions.LocalizedName(x.SuperUniqueName))).ToArray();
                 if (superUniques.Count() > 0) return superUniques;
 
                 return new (UnitMonster, string)[] { };

--- a/Helpers/ExcelDataLoader.cs
+++ b/Helpers/ExcelDataLoader.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace MapAssist.Helpers
+{
+    internal static class ExcelDataLoader
+    {
+        public static List<Dictionary<string, string>> Parse(string text)
+        {
+            var items = new List<Dictionary<string, string>>();
+            
+            var lines = text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Split('\t').ToArray()).ToArray();
+            var headers = lines[0].Select(x => Regex.Replace(x, @"\s+", "")).ToArray();
+
+            foreach (var line in lines.Skip(1).ToArray())
+            {
+                if (line[0] == "Expansion") continue; // Blizz likes to insert stupid nonsense in their files
+
+                items.Add(line.Select((item, index) => new { item, index }).ToDictionary(x => headers[x.index], x => x.item));
+            }
+
+            return items;
+        }
+    }
+}

--- a/Helpers/GameDataReader.cs
+++ b/Helpers/GameDataReader.cs
@@ -1,6 +1,9 @@
-﻿using MapAssist.Types;
+﻿using GameOverlay.Drawing;
+using MapAssist.Settings;
+using MapAssist.Types;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MapAssist.Helpers
 {
@@ -9,10 +12,9 @@ namespace MapAssist.Helpers
         private static readonly NLog.Logger _log = NLog.LogManager.GetCurrentClassLogger();
         private volatile GameData _gameData;
         private AreaData _areaData;
-        private List<PointOfInterest> _pointsOfInterest;
         private MapApi _mapApi;
 
-        public (GameData, AreaData, List<PointOfInterest>, bool) Get()
+        public (GameData, AreaData, bool) Get()
         {
             var gameData = GameMemory.GetGameData();
             var changed = false;
@@ -22,7 +24,7 @@ namespace MapAssist.Helpers
                 if (gameData.HasGameChanged(_gameData))
                 {
                     _log.Info($"Game changed to {gameData.Difficulty} with {gameData.MapSeed} seed");
-                    _mapApi = new MapApi(gameData.Difficulty, gameData.MapSeed);
+                    _mapApi = new MapApi(gameData);
                 }
 
                 if (gameData.HasMapChanged(_gameData) && gameData.Area != Area.None)
@@ -30,14 +32,14 @@ namespace MapAssist.Helpers
                     _log.Info($"Area changed to {gameData.Area}");
                     _areaData = _mapApi.GetMapData(gameData.Area);
 
-                    if (_areaData != null)
-                    {
-                        _pointsOfInterest = PointOfInterestHandler.Get(_mapApi, _areaData, gameData);
-                        _log.Info($"Found {_pointsOfInterest.Count} points of interest");
-                    }
-                    else
+                    if (_areaData == null)
                     {
                         _log.Info($"Area data not loaded");
+                    }
+                    else if (_areaData.PointsOfInterest == null)
+                    {
+                        _areaData.PointsOfInterest = PointOfInterestHandler.Get(_mapApi, _areaData, gameData);
+                        _log.Info($"Found {_areaData.PointsOfInterest.Count} points of interest");
                     }
 
                     changed = true;
@@ -45,8 +47,41 @@ namespace MapAssist.Helpers
             }
 
             _gameData = gameData;
+            
+            ImportFromGameData();
 
-            return (_gameData, _areaData, _pointsOfInterest, changed);
+            return (_gameData, _areaData, changed);
+        }
+
+        private void ImportFromGameData()
+        {
+            if (_gameData == null || _areaData == null) return;
+
+            foreach (var gameObject in _gameData.Objects)
+            {
+                if (!_areaData.IncludesPoint(gameObject.Position)) continue;
+
+                if (gameObject.IsShrine || gameObject.IsWell)
+                {
+                    var existingPoint = _areaData.PointsOfInterest.FirstOrDefault(x => x.Position == gameObject.Position);
+
+                    if (existingPoint != null)
+                    {
+                        existingPoint.Label = Shrine.ShrineDisplayName(gameObject);
+                    }
+                    else
+                    {
+                        _areaData.PointsOfInterest.Add(new PointOfInterest()
+                        {
+                            Area = _areaData.Area,
+                            Label = Shrine.ShrineDisplayName(gameObject),
+                            Position = gameObject.Position,
+                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.Shrine,
+                            Type = PoiType.Shrine
+                        });
+                    }
+                }
+            }
         }
     }
 }

--- a/Helpers/GameDataReader.cs
+++ b/Helpers/GameDataReader.cs
@@ -1,8 +1,5 @@
-﻿using GameOverlay.Drawing;
-using MapAssist.Settings;
+﻿using MapAssist.Settings;
 using MapAssist.Types;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace MapAssist.Helpers
@@ -47,7 +44,7 @@ namespace MapAssist.Helpers
             }
 
             _gameData = gameData;
-            
+
             ImportFromGameData();
 
             return (_gameData, _areaData, changed);

--- a/Helpers/GameManager.cs
+++ b/Helpers/GameManager.cs
@@ -27,7 +27,6 @@ namespace MapAssist.Helpers
         private static IntPtr _UnitHashTableOffset;
         private static IntPtr _ExpansionCheckOffset;
         private static IntPtr _GameNameOffset;
-        private static IntPtr _MenuPanelOpenOffset;
         private static IntPtr _MenuDataOffset;
         private static IntPtr _MapSeedOffset;
         private static IntPtr _RosterDataOffset;
@@ -125,7 +124,6 @@ namespace MapAssist.Helpers
             _UnitHashTableOffset = IntPtr.Zero;
             _ExpansionCheckOffset = IntPtr.Zero;
             _GameNameOffset = IntPtr.Zero;
-            _MenuPanelOpenOffset = IntPtr.Zero;
             _MenuDataOffset = IntPtr.Zero;
             _MapSeedOffset = IntPtr.Zero;
             _RosterDataOffset = IntPtr.Zero;
@@ -210,21 +208,6 @@ namespace MapAssist.Helpers
                 PopulateMissingOffsets();
 
                 return _GameNameOffset;
-            }
-        }
-
-        public static IntPtr MenuOpenOffset
-        {
-            get
-            {
-                if (_MenuPanelOpenOffset != IntPtr.Zero)
-                {
-                    return _MenuPanelOpenOffset;
-                }
-
-                PopulateMissingOffsets();
-
-                return _MenuPanelOpenOffset;
             }
         }
 
@@ -327,12 +310,6 @@ namespace MapAssist.Helpers
                 {
                     _GameNameOffset = processContext.GetGameNameOffset(buffer);
                     _log.Info($"Found offset {nameof(_GameNameOffset)} 0x{_GameNameOffset.ToInt64() - processContext.BaseAddr.ToInt64():X}");
-                }
-
-                if (_MenuPanelOpenOffset == IntPtr.Zero)
-                {
-                    _MenuPanelOpenOffset = processContext.GetMenuOpenOffset(buffer);
-                    _log.Info($"Found offset {nameof(_MenuPanelOpenOffset)} 0x{_MenuPanelOpenOffset.ToInt64() - processContext.BaseAddr.ToInt64():X}");
                 }
 
                 if (_MenuDataOffset == IntPtr.Zero)

--- a/Helpers/GameManager.cs
+++ b/Helpers/GameManager.cs
@@ -32,6 +32,7 @@ namespace MapAssist.Helpers
         private static IntPtr _RosterDataOffset;
         private static IntPtr _InteractedNpcOffset;
         private static IntPtr _LastHoverDataOffset;
+        private static IntPtr _PetsOffsetOffset;
 
         private static WindowsExternal.WinEventDelegate _eventDelegate = null;
 
@@ -129,6 +130,7 @@ namespace MapAssist.Helpers
             _RosterDataOffset = IntPtr.Zero;
             _InteractedNpcOffset = IntPtr.Zero;
             _LastHoverDataOffset = IntPtr.Zero;
+            _PetsOffsetOffset = IntPtr.Zero;
 
             _lastGameHwnd = hwnd;
             _lastGameProcess = process;
@@ -286,6 +288,21 @@ namespace MapAssist.Helpers
             }
         }
 
+        public static IntPtr PetsOffset
+        {
+            get
+            {
+                if (_PetsOffsetOffset != IntPtr.Zero)
+                {
+                    return _PetsOffsetOffset;
+                }
+
+                PopulateMissingOffsets();
+
+                return _PetsOffsetOffset;
+            }
+        }
+
         private static void PopulateMissingOffsets()
         {
             // The fact we are here means we are missing some offset,
@@ -340,6 +357,12 @@ namespace MapAssist.Helpers
                 {
                     _InteractedNpcOffset = processContext.GetInteractedNpcOffset(buffer);
                     _log.Info($"Found offset {nameof(_InteractedNpcOffset)} 0x{_InteractedNpcOffset.ToInt64() - processContext.BaseAddr.ToInt64():X}");
+                }
+
+                if (_PetsOffsetOffset == IntPtr.Zero)
+                {
+                    _PetsOffsetOffset = processContext.GetPetsOffset(buffer);
+                    _log.Info($"Found offset {nameof(_PetsOffsetOffset)} 0x{_PetsOffsetOffset.ToInt64() - processContext.BaseAddr.ToInt64():X}");
                 }
             }
         }

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -41,7 +41,6 @@ namespace MapAssist.Helpers
             {
                 _currentProcessId = processContext.ProcessId;
 
-                var menuOpen = processContext.Read<byte>(GameManager.MenuOpenOffset);
                 var menuData = processContext.Read<Structs.MenuData>(GameManager.MenuDataOffset);
                 var lastHoverData = processContext.Read<Structs.HoverData>(GameManager.LastHoverDataOffset);
                 var lastNpcInteracted = (Npc)processContext.Read<ushort>(GameManager.InteractedNpcOffset);
@@ -383,7 +382,6 @@ namespace MapAssist.Helpers
                     Session = _sessions[_currentProcessId],
                     Roster = rosterData,
                     MenuOpen = menuData,
-                    MenuPanelOpen = menuOpen,
                     LastNpcInteracted = lastNpcInteracted,
                     ProcessId = _currentProcessId
                 };

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -40,6 +40,7 @@ namespace MapAssist.Helpers
             using (processContext)
             {
                 _currentProcessId = processContext.ProcessId;
+                var currentWindowHandle = GameManager.MainWindowHandle;
 
                 var menuData = processContext.Read<Structs.MenuData>(GameManager.MenuDataOffset);
                 var lastHoverData = processContext.Read<Structs.HoverData>(GameManager.LastHoverDataOffset);
@@ -353,12 +354,12 @@ namespace MapAssist.Helpers
                 _firstMemoryRead = false;
                 _errorThrown = false;
 
-                if (_currentProcessId != processContext.ProcessId)
+                if (currentWindowHandle != GameManager.MainWindowHandle)
                 {
                     if (_errorThrown) return null;
 
                     _errorThrown = true;
-                    throw new Exception("Process ID changed in the middle of the frame.");
+                    throw new Exception("Window handle changed in the middle of the frame");
                 }
 
                 return new GameData
@@ -367,7 +368,7 @@ namespace MapAssist.Helpers
                     MapSeed = mapSeed,
                     Area = levelId,
                     Difficulty = gameDifficulty,
-                    MainWindowHandle = GameManager.MainWindowHandle,
+                    MainWindowHandle = currentWindowHandle,
                     PlayerName = playerUnit.Name,
                     PlayerUnit = playerUnit,
                     Players = playerList,

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -46,6 +46,7 @@ namespace MapAssist.Helpers
                 var lastHoverData = processContext.Read<Structs.HoverData>(GameManager.LastHoverDataOffset);
                 var lastNpcInteracted = (Npc)processContext.Read<ushort>(GameManager.InteractedNpcOffset);
                 var rosterData = new Roster(GameManager.RosterDataOffset);
+                var pets = new Pets(GameManager.PetsOffset);
 
                 if (!menuData.InGame)
                 {
@@ -211,7 +212,19 @@ namespace MapAssist.Helpers
                     .Where(x => x != null && x.UnitId < uint.MaxValue).ToArray();
 
                 var monsterList = rawMonsterUnits.Where(x => x.UnitType == UnitType.Monster && x.IsMonster).ToArray();
-                var mercList = rawMonsterUnits.Where(x => x.UnitType == UnitType.Monster && x.IsMerc).ToArray();
+
+                foreach (var petEntry in pets.List.Where(x => x.IsMerc).ToArray())
+                {
+                    var merc = rawMonsterUnits.FirstOrDefault(x => x.UnitId == petEntry.UnitId);
+
+                    if (merc != null)
+                    {
+                        petEntry.IsPlayerOwned = playerUnit.UnitId == petEntry.OwnerId;
+                        merc.PetEntry = petEntry;
+                    }
+                }
+
+                var mercList = rawMonsterUnits.Where(x => x.IsMerc).ToArray();
 
                 // Objects
                 var rawObjectUnits = GetUnits<UnitObject>(UnitType.Object, true);

--- a/Helpers/ItemExport.cs
+++ b/Helpers/ItemExport.cs
@@ -146,6 +146,7 @@ namespace MapAssist.Helpers
                     baseName = item.ItemBaseName,
                     quality = item.ItemData.ItemQuality.ToString(),
                     fullName = Items.ItemFullName(item),
+                    runeWord = item.IsRuneWord ? Items.GetRunewordFromId(item.Prefixes[0]) : null,
                     ethereal = item.IsEthereal,
                     identified = item.IsIdentified,
                     numSockets = numSockets,

--- a/Helpers/ItemExport.cs
+++ b/Helpers/ItemExport.cs
@@ -146,7 +146,7 @@ namespace MapAssist.Helpers
                     baseName = item.ItemBaseName,
                     quality = item.ItemData.ItemQuality.ToString(),
                     fullName = Items.ItemFullName(item),
-                    ethereal = ((item.ItemData.ItemFlags & ItemFlags.IFLAG_ETHEREAL) == ItemFlags.IFLAG_ETHEREAL),
+                    ethereal = item.IsEthereal,
                     identified = item.IsIdentified,
                     numSockets = numSockets,
                     position = new Position() { x = (uint)item.Position.X, y = (uint)item.Position.Y },

--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -37,7 +37,7 @@ namespace MapAssist.Helpers
                 {
                     ["Qualities"]       = () => rule.Qualities.Contains(item.ItemData.ItemQuality),
                     ["Sockets"]         = () => rule.Sockets.Contains(Items.GetItemStat(item, Stats.Stat.NumSockets)),
-                    ["Ethereal"]        = () => ((item.ItemData.ItemFlags & ItemFlags.IFLAG_ETHEREAL) == ItemFlags.IFLAG_ETHEREAL) == rule.Ethereal,
+                    ["Ethereal"]        = () => item.IsEthereal == rule.Ethereal,
                     ["MinAreaLevel"]    = () => areaLevel >= rule.MinAreaLevel,
                     ["MaxAreaLevel"]    = () => areaLevel <= rule.MaxAreaLevel,
                     ["MinPlayerLevel"]  = () => playerLevel >= rule.MinPlayerLevel,

--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -29,24 +29,24 @@ namespace MapAssist.Helpers
             // Scan the list of rules
             foreach (var rule in matches.SelectMany(kv => kv.Value))
             {
-                // Skip generic unid rules for identified items
-                if (item.IsIdentified && rule.TargetsUnidItem()) continue;
+                // Skip generic unid rules for identified items on ground
+                if (item.IsIdentified && item.IsDropped && rule.TargetsUnidItem()) continue;
 
                 // Requirement check functions
                 var requirementsFunctions = new Dictionary<string, Func<bool>>()
                 {
-                    ["Qualities"]       = () => rule.Qualities.Contains(item.ItemData.ItemQuality),
-                    ["Sockets"]         = () => rule.Sockets.Contains(Items.GetItemStat(item, Stats.Stat.NumSockets)),
-                    ["Ethereal"]        = () => item.IsEthereal == rule.Ethereal,
-                    ["MinAreaLevel"]    = () => areaLevel >= rule.MinAreaLevel,
-                    ["MaxAreaLevel"]    = () => areaLevel <= rule.MaxAreaLevel,
-                    ["MinPlayerLevel"]  = () => playerLevel >= rule.MinPlayerLevel,
-                    ["MaxPlayerLevel"]  = () => playerLevel <= rule.MaxPlayerLevel,
+                    ["Qualities"] = () => rule.Qualities.Contains(item.ItemData.ItemQuality),
+                    ["Sockets"] = () => rule.Sockets.Contains(Items.GetItemStat(item, Stats.Stat.NumSockets)),
+                    ["Ethereal"] = () => item.IsEthereal == rule.Ethereal,
+                    ["MinAreaLevel"] = () => areaLevel >= rule.MinAreaLevel,
+                    ["MaxAreaLevel"] = () => areaLevel <= rule.MaxAreaLevel,
+                    ["MinPlayerLevel"] = () => playerLevel >= rule.MinPlayerLevel,
+                    ["MaxPlayerLevel"] = () => playerLevel <= rule.MaxPlayerLevel,
                     ["MinQualityLevel"] = () => Items.GetQualityLevel(item) >= rule.MinQualityLevel,
                     ["MaxQualityLevel"] = () => Items.GetQualityLevel(item) <= rule.MaxQualityLevel,
-                    ["AllAttributes"]   = () => Items.GetItemStatAllAttributes(item) >= rule.AllAttributes,
-                    ["AllResist"]       = () => Items.GetItemStatResists(item, false) >= rule.AllResist,
-                    ["SumResist"]       = () => Items.GetItemStatResists(item, true) >= rule.SumResist,
+                    ["AllAttributes"] = () => Items.GetItemStatAllAttributes(item) >= rule.AllAttributes,
+                    ["AllResist"] = () => Items.GetItemStatResists(item, false) >= rule.AllResist,
+                    ["SumResist"] = () => Items.GetItemStatResists(item, true) >= rule.SumResist,
                     ["ClassSkills"] = () =>
                     {
                         if (rule.ClassSkills.Count() == 0) return true;

--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -29,8 +29,8 @@ namespace MapAssist.Helpers
             // Scan the list of rules
             foreach (var rule in matches.SelectMany(kv => kv.Value))
             {
-                // Skip generic unid rules for identified items on ground
-                if (item.IsIdentified && item.IsDropped && rule.TargetsUnidItem()) continue;
+                // Skip generic unid rules for identified items on ground or in inventory
+                if (item.IsIdentified && (item.IsDropped || item.IsAnyPlayerHolding) && rule.TargetsUnidItem()) continue;
 
                 // Requirement check functions
                 var requirementsFunctions = new Dictionary<string, Func<bool>>()

--- a/Helpers/MapApi.cs
+++ b/Helpers/MapApi.cs
@@ -94,28 +94,28 @@ namespace MapAssist.Helpers
             while (true)
             {
                 var providedPath = MapAssistConfiguration.Loaded.D2LoDPath;
-                if (!string.IsNullOrEmpty(providedPath) && !IsValidD2LoDPath(providedPath))
+                if (!string.IsNullOrEmpty(providedPath))
                 {
-                    _log.Info("User provided D2 LoD path not found or invalid");
-                    var diabloResult = MessageBox.Show("Provided D2 LoD path is not valid." + Environment.NewLine + Environment.NewLine + "Please provide a path to a D2 LoD 1.13c installation.", "MapAssist", MessageBoxButtons.OKCancel);
-
-                    if (diabloResult == DialogResult.Cancel)
-                    {
-                        Environment.Exit(0);
-                    }
-
-                    var config = new ConfigEditor();
-                    config.ShowDialog();
-
-                    providedPath = MapAssistConfiguration.Loaded.D2LoDPath;
-
                     if (IsValidD2LoDPath(providedPath))
                     {
                         _log.Info("User provided D2 LoD path is valid");
                         return providedPath;
                     }
+                    else
+                    {
+                        _log.Info("User provided D2 LoD path not found or invalid");
+                        var diabloResult = MessageBox.Show("Provided D2 LoD path is not valid." + Environment.NewLine + Environment.NewLine + "Please provide a path to a D2 LoD 1.13c installation.", "MapAssist", MessageBoxButtons.OKCancel);
 
-                    continue;
+                        if (diabloResult == DialogResult.Cancel)
+                        {
+                            Environment.Exit(0);
+                        }
+
+                        var config = new ConfigEditor();
+                        config.ShowDialog();
+
+                        continue;
+                    }
                 }
 
                 var installPath = Registry.GetValue("HKEY_CURRENT_USER\\SOFTWARE\\Blizzard Entertainment\\Diablo II", "InstallPath", "INVALID") as string;

--- a/Helpers/MapApi.cs
+++ b/Helpers/MapApi.cs
@@ -91,60 +91,57 @@ namespace MapAssist.Helpers
 
         private static string FindD2LoD()
         {
-            var providedPath = MapAssistConfiguration.Loaded.D2LoDPath;
-            if (!string.IsNullOrEmpty(providedPath))
+            while (true)
             {
-                if (!File.GetAttributes($@"{providedPath}").HasFlag(FileAttributes.Directory))
+                var providedPath = MapAssistConfiguration.Loaded.D2LoDPath;
+                if (!string.IsNullOrEmpty(providedPath) && !IsValidD2LoDPath(providedPath))
                 {
-                    MessageBox.Show("Provided D2 LoD path is not set to a directory." + Environment.NewLine + Environment.NewLine + "Please provide a path to a D2 LoD 1.13c installation.", "MapAssist");
+                    _log.Info("User provided D2 LoD path not found or invalid");
+                    var diabloResult = MessageBox.Show("Provided D2 LoD path is not valid." + Environment.NewLine + Environment.NewLine + "Please provide a path to a D2 LoD 1.13c installation.", "MapAssist", MessageBoxButtons.OKCancel);
 
-                    var config1 = new ConfigEditor();
-                    config1.ShowDialog();
+                    if (diabloResult == DialogResult.Cancel)
+                    {
+                        Environment.Exit(0);
+                    }
+
+                    var config = new ConfigEditor();
+                    config.ShowDialog();
 
                     providedPath = MapAssistConfiguration.Loaded.D2LoDPath;
+
+                    if (IsValidD2LoDPath(providedPath))
+                    {
+                        _log.Info("User provided D2 LoD path is valid");
+                        return providedPath;
+                    }
+
+                    continue;
                 }
 
-                if (IsValidD2LoDPath(providedPath))
+                var installPath = Registry.GetValue("HKEY_CURRENT_USER\\SOFTWARE\\Blizzard Entertainment\\Diablo II", "InstallPath", "INVALID") as string;
+                if (installPath == "INVALID" || !IsValidD2LoDPath(installPath))
                 {
-                    _log.Info("User provided D2 LoD path is valid");
-                    return providedPath;
+                    _log.Info("Registry provided D2 LoD path not found or invalid");
+                    MessageBox.Show("Unable to automatically locate D2 LoD installation." + Environment.NewLine + Environment.NewLine + "Please provide a path to a D2 LoD 1.13c installation.", "MapAssist");
+
+                    var config = new ConfigEditor();
+                    config.ShowDialog();
+
+                    continue;
                 }
 
-                _log.Info("User provided D2 LoD path is invalid");
-                MessageBox.Show("Provided path is either not a valid D2 LoD path or not the correct version.", "MapAssist");
-                Environment.Exit(0);
+                _log.Info("Registry provided D2 LoD path is valid");
+                return installPath;
             }
-
-            var installPath = Registry.GetValue("HKEY_CURRENT_USER\\SOFTWARE\\Blizzard Entertainment\\Diablo II", "InstallPath", "INVALID") as string;
-            if (installPath == "INVALID" || !IsValidD2LoDPath(installPath))
-            {
-                _log.Info("Registry-provided D2 LoD path not found or invalid");
-                MessageBox.Show("Unable to automatically locate D2 LoD installation." + Environment.NewLine + Environment.NewLine + "Please provide a path to a D2 LoD 1.13c installation.", "MapAssist");
-
-                var config = new ConfigEditor();
-                config.ShowDialog();
-
-                installPath = MapAssistConfiguration.Loaded.D2LoDPath;
-
-                if (!string.IsNullOrEmpty(installPath) && File.GetAttributes($@"{installPath}").HasFlag(FileAttributes.Directory) && IsValidD2LoDPath(installPath))
-                {
-                    _log.Info("User provided D2 LoD path is valid");
-                    return installPath;
-                }
-
-                _log.Info("User provided D2 LoD path is invalid");
-                MessageBox.Show("Provided path is either not a valid D2 LoD path or not the correct version.", "MapAssist");
-                Environment.Exit(0);
-            }
-
-            _log.Info("Registry-provided D2 LoD path is valid");
-            return installPath;
         }
 
         private static bool IsValidD2LoDPath(string path)
         {
             try
             {
+                if (string.IsNullOrEmpty(path)) return false;
+                if (!File.GetAttributes(path).HasFlag(FileAttributes.Directory)) return false;
+
                 var gamePath = Path.Combine(path, "game.exe");
                 if (File.Exists(gamePath))
                 {

--- a/Helpers/Pattern.cs
+++ b/Helpers/Pattern.cs
@@ -11,7 +11,7 @@ namespace MapAssist.Helpers
 
         public Pattern(string pattern)
         {
-            List<string> cleanPattern = pattern
+            var cleanPattern = pattern
                 .Replace("\\x", " ")
                 .Replace("??", "?")
                 .Trim()
@@ -23,7 +23,7 @@ namespace MapAssist.Helpers
 
             _pattern = cleanPattern
                 .Select(o => byte.Parse(o, NumberStyles.HexNumber))
-                .ToArray();            
+                .ToArray();
         }
 
         public bool Match(byte[] data, int offset)
@@ -42,9 +42,7 @@ namespace MapAssist.Helpers
 
         public override string ToString()
         {
-            return "Pattern: " + string.Join(
-                " ", _mask.Select((c, i) => c == '?' ? "?" : _pattern[i].ToString("X"))
-            );
+            return "Pattern: " + string.Join(" ", _mask.Select((c, i) => c == '?' ? "?" : _pattern[i].ToString("X").PadLeft(2, '0')));
         }
     }
 }

--- a/Helpers/PointOfInterestHandler.cs
+++ b/Helpers/PointOfInterestHandler.cs
@@ -3,7 +3,6 @@ using MapAssist.Settings;
 using MapAssist.Types;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace MapAssist.Helpers
 {
@@ -190,14 +189,15 @@ namespace MapAssist.Helpers
                         Area.TalRashasTomb5, Area.TalRashasTomb6, Area.TalRashasTomb7
                     };
                     var realTomb = Area.None;
-                    Parallel.ForEach(tombs, tombArea =>
+                    foreach (var tombArea in tombs)
                     {
                         AreaData tombData = mapApi.GetMapData(tombArea);
                         if (tombData.Objects.ContainsKey(GameObject.HoradricOrifice))
                         {
                             realTomb = tombArea;
+                            break;
                         }
-                    });
+                    }
 
                     if (realTomb != Area.None && areaData.AdjacentLevels[realTomb].Exits.Any())
                     {

--- a/Helpers/PointOfInterestHandler.cs
+++ b/Helpers/PointOfInterestHandler.cs
@@ -171,25 +171,6 @@ namespace MapAssist.Helpers
 
         public static List<PointOfInterest> Get(MapApi mapApi, AreaData areaData, GameData gameData)
         {
-            var pointsOfInterest = GetArea(mapApi, areaData, gameData);
-
-            if (AreaExtensions.RequiresStitching(areaData.Area))
-            {
-                foreach (var adjacentArea in areaData.AdjacentAreas.Values.ToList())
-                {
-                    if (AreaExtensions.RequiresStitching(adjacentArea.Area))
-                    {
-                        var adjacentPoi = GetArea(mapApi, adjacentArea, gameData).Where(a => !pointsOfInterest.Any(b => a.Position.Subtract(b.Position).Length() < 5)).ToList(); // Prevent poi in an adjacent area from overlapping with poi in the current area
-                        pointsOfInterest.AddRange(adjacentPoi);
-                    }
-                }
-            }
-
-            return pointsOfInterest;
-        }
-
-        public static List<PointOfInterest> GetArea(MapApi mapApi, AreaData areaData, GameData gameData)
-        {
             var pointsOfInterest = new List<PointOfInterest>();
             var areaRenderDecided = new List<Area>();
 
@@ -393,7 +374,7 @@ namespace MapAssist.Helpers
                 else if (areaData.Area == Area.Barracks)
                 {
                     var outerCloisterArea = mapApi.GetMapData(Area.OuterCloister);
-                    var barracksAreaData = GetArea(mapApi, outerCloisterArea, gameData);
+                    var barracksAreaData = Get(mapApi, outerCloisterArea, gameData);
                     var barracks = barracksAreaData.FirstOrDefault(poi => poi.Type == PoiType.NextArea);
 
                     pointsOfInterest.Add(new PointOfInterest
@@ -527,7 +508,7 @@ namespace MapAssist.Helpers
                         pointsOfInterest.Add(new PointOfInterest
                         {
                             Area = areaData.Area,
-                            Label = obj.ToString(),
+                            Label = "",
                             Position = point,
                             RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.Shrine,
                             Type = PoiType.Shrine
@@ -596,7 +577,7 @@ namespace MapAssist.Helpers
                     break;
             }
 
-            return pointsOfInterest;
+            return pointsOfInterest.Where(poi => poi.Area == areaData.Area).ToList();
         }
     }
 }

--- a/Helpers/PointOfInterestHandler.cs
+++ b/Helpers/PointOfInterestHandler.cs
@@ -22,7 +22,7 @@ namespace MapAssist.Helpers
             [Area.RockyWaste] = Area.DryHills,
             [Area.DryHills] = Area.FarOasis,
             [Area.FarOasis] = Area.LostCity,
-            [Area.SpiderForest] = Area.GreatMarsh,
+            [Area.SpiderForest] = Area.FlayerJungle,
             [Area.FlayerJungle] = Area.LowerKurast,
             [Area.KurastBazaar] = Area.UpperKurast,
             [Area.UpperKurast] = Area.KurastCauseway,
@@ -40,7 +40,7 @@ namespace MapAssist.Helpers
             [Area.LostCity] = Area.ValleyOfSnakes,
             [Area.SpiderForest] = Area.SpiderCavern,
             [Area.FlayerJungle] = Area.FlayerDungeonLevel1,
-            [Area.KurastBazaar] = Area.RuinedTemple,
+            [Area.KurastBazaar] = Area.SewersLevel1Act3,
             [Area.CrystallinePassage] = Area.FrozenRiver,
         };
 

--- a/Helpers/PointOfInterestHandler.cs
+++ b/Helpers/PointOfInterestHandler.cs
@@ -22,7 +22,6 @@ namespace MapAssist.Helpers
             [Area.RockyWaste] = Area.DryHills,
             [Area.DryHills] = Area.FarOasis,
             [Area.FarOasis] = Area.LostCity,
-            [Area.SpiderForest] = Area.FlayerJungle,
             [Area.FlayerJungle] = Area.LowerKurast,
             [Area.KurastBazaar] = Area.UpperKurast,
             [Area.UpperKurast] = Area.KurastCauseway,
@@ -296,6 +295,51 @@ namespace MapAssist.Helpers
                         Type = PoiType.NextArea
                     });
                     areaRenderDecided.Add(Area.InnerCloister);
+                }
+                else if (areaData.Area == Area.SpiderForest)
+                {
+                    if (areaData.AdjacentLevels.TryGetValue(Area.FlayerJungle, out var flayerJungleLevel))
+                    {
+                        pointsOfInterest.Add(new PointOfInterest
+                        {
+                            Area = areaData.Area,
+                            NextArea = Area.FlayerJungle,
+                            Label = Area.FlayerJungle.MapLabel(gameData.Difficulty),
+                            Position = flayerJungleLevel.Exits[0],
+                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.NextArea,
+                            Type = PoiType.NextArea
+                        });
+                        areaRenderDecided.Add(Area.FlayerJungle);
+                    }
+                    else if (areaData.AdjacentLevels.TryGetValue(Area.GreatMarsh, out var greatMarshLevel))
+                    {
+                        pointsOfInterest.Add(new PointOfInterest
+                        {
+                            Area = areaData.Area,
+                            NextArea = Area.GreatMarsh,
+                            Label = Area.GreatMarsh.MapLabel(gameData.Difficulty),
+                            Position = greatMarshLevel.Exits[0],
+                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.NextArea,
+                            Type = PoiType.NextArea
+                        });
+                        areaRenderDecided.Add(Area.GreatMarsh);
+                    }
+                }
+                else if (areaData.Area == Area.GreatMarsh)
+                {
+                    if (areaData.AdjacentLevels.TryGetValue(Area.FlayerJungle, out var flayerJungleLevel))
+                    {
+                        pointsOfInterest.Add(new PointOfInterest
+                        {
+                            Area = areaData.Area,
+                            NextArea = Area.FlayerJungle,
+                            Label = Area.FlayerJungle.MapLabel(gameData.Difficulty),
+                            Position = flayerJungleLevel.Exits[0],
+                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.NextArea,
+                            Type = PoiType.NextArea
+                        });
+                        areaRenderDecided.Add(Area.FlayerJungle);
+                    }
                 }
                 else if (AreaPreferredNextArea.TryGetValue(areaData.Area, out var nextArea))
                 {

--- a/Helpers/ProcessContext.cs
+++ b/Helpers/ProcessContext.cs
@@ -29,11 +29,11 @@ namespace MapAssist.Helpers
 
         public IntPtr GetUnitHashtableOffset(byte[] buffer)
         {
-            var pattern = new Pattern("48 8D 0D ? ? ? ? 48 C1 E0 0A 48 03 C1 C3 CC");
+            var pattern = new Pattern("48 03 C7 49 8B 8C C6");
             var patternAddress = FindPattern(buffer, pattern);
 
             var offsetBuffer = new byte[4];
-            var resultRelativeAddress = IntPtr.Add(patternAddress, 3);
+            var resultRelativeAddress = IntPtr.Add(patternAddress, 7);
             if (!WindowsExternal.ReadProcessMemory(_handle, resultRelativeAddress, offsetBuffer, sizeof(int), out _))
             {
                 _log.Info($"Failed to find pattern {pattern}");
@@ -41,8 +41,7 @@ namespace MapAssist.Helpers
             }
 
             var offsetAddressToInt = BitConverter.ToInt32(offsetBuffer, 0);
-            var delta = patternAddress.ToInt64() - _baseAddr.ToInt64();
-            return IntPtr.Add(_baseAddr, (int)(delta + 7 + offsetAddressToInt));
+            return IntPtr.Add(_baseAddr, offsetAddressToInt);
         }
 
         public IntPtr GetExpansionOffset(byte[] buffer)

--- a/Helpers/YamlConverters.cs
+++ b/Helpers/YamlConverters.cs
@@ -29,6 +29,27 @@ namespace MapAssist.Helpers
         }
     }
 
+    internal sealed class ColorConfigurationTypeConverter : IYamlTypeConverter
+    {
+        public bool Accepts(Type type)
+        {
+            return type == typeof(Color) || type == typeof(Color?);
+        }
+
+        public object ReadYaml(IParser parser, Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteYaml(IEmitter emitter, object value, Type type)
+        {
+            if (value != null)
+            {
+                emitter.Emit(new Scalar(null, Helpers.GetColorName((Color)value)));
+            }
+        }
+    }
+
     internal sealed class MapColorConfigurationTypeConverter : IYamlTypeConverter
     {
         public bool Accepts(Type type)
@@ -48,15 +69,13 @@ namespace MapAssist.Helpers
             var node = (MapColorConfiguration)value;
             if (node.Walkable != null)
             {
-                var col = (Color)node.Walkable;
                 emitter.Emit(new Scalar(null, "Walkable"));
-                emitter.Emit(new Scalar(null, col.R + ", " + col.G + ", " + col.B));
+                emitter.Emit(new Scalar(null, Helpers.GetColorName((Color)node.Walkable)));
             }
             if (node.Border != null)
             {
-                var col = (Color)node.Border;
                 emitter.Emit(new Scalar(null, "Border"));
-                emitter.Emit(new Scalar(null, col.R + ", " + col.G + ", " + col.B));
+                emitter.Emit(new Scalar(null, Helpers.GetColorName((Color)node.Border)));
             }
 
             emitter.Emit(new MappingEnd());

--- a/MapAssist.csproj
+++ b/MapAssist.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Files\Font\ResourceFontFileStream.cs" />
     <Compile Include="Files\Font\ResourceFontLoader.cs" />
     <Compile Include="Helpers\AudioPlayer.cs" />
+    <Compile Include="Helpers\ExcelDataLoader.cs" />
     <Compile Include="Helpers\GameDataReader.cs" />
     <Compile Include="Helpers\GameManager.cs" />
     <Compile Include="Helpers\Hotkey.cs" />
@@ -267,6 +268,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\QualityLevels.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\SuperUniques.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Salvation.png" />

--- a/MapAssist.csproj
+++ b/MapAssist.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Structs\RoomEx.cs" />
     <Compile Include="Structs\Session.cs" />
     <Compile Include="Structs\Skill.cs" />
+    <Compile Include="Structs\Pet.cs" />
     <Compile Include="Structs\UnitAny.cs" />
     <Compile Include="Structs\UnitHashTable.cs" />
     <Compile Include="Types\Chest.cs" />
@@ -205,6 +206,7 @@
     <Compile Include="Types\UnitPlayer.cs" />
     <Compile Include="Types\UnitMonster.cs" />
     <Compile Include="Types\UnitItem.cs" />
+    <Compile Include="Types\Pets.cs" />
     <Compile Include="Types\UnitType.cs" />
     <EmbeddedResource Include="Forms\AddAreaForm.resx">
       <DependentUpon>AddAreaForm.cs</DependentUpon>

--- a/MapAssist.csproj
+++ b/MapAssist.csproj
@@ -127,6 +127,8 @@
     <Compile Include="Files\Font\ResourceFontFileStream.cs" />
     <Compile Include="Files\Font\ResourceFontLoader.cs" />
     <Compile Include="Helpers\AudioPlayer.cs" />
+    <Compile Include="Helpers\BossKillCountRepository.cs" />
+    <Compile Include="Helpers\BossStateTracker.cs" />
     <Compile Include="Helpers\ExcelDataLoader.cs" />
     <Compile Include="Helpers\GameDataReader.cs" />
     <Compile Include="Helpers\GameManager.cs" />
@@ -232,6 +234,9 @@
     </PackageReference>
     <PackageReference Include="HotkeyListener">
       <Version>1.9.0</Version>
+    </PackageReference>
+    <PackageReference Include="LiteDB">
+      <Version>5.0.11</Version>
     </PackageReference>
     <PackageReference Include="MouseKeyHook">
       <Version>5.6.0</Version>

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -6,8 +6,6 @@ using MapAssist.Structs;
 using MapAssist.Types;
 using System;
 using System.Windows.Forms;
-
-//using WK.Libraries.HotkeyListenerNS;
 using Graphics = GameOverlay.Drawing.Graphics;
 
 namespace MapAssist

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -134,7 +134,7 @@ namespace MapAssist
 
         public void KeyDownHandler(object sender, KeyEventArgs args)
         {
-            if (InGame() && GameManager.IsGameInForeground)
+            if (InGame() && GameManager.IsGameInForeground && !_gameData.MenuOpen.Chat)
             {
                 var keys = new Hotkey(args.Modifiers, args.KeyCode);
 

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -49,12 +49,12 @@ namespace MapAssist
             {
                 lock (_lock)
                 {
-                    var (gameData, areaData, pointsOfInterest, changed) = _gameDataReader.Get();
+                    var (gameData, areaData, changed) = _gameDataReader.Get();
                     _gameData = gameData;
 
                     if (changed)
                     {
-                        _compositor.SetArea(areaData, pointsOfInterest);
+                        _compositor.SetArea(areaData);
                     }
 
                     gfx.ClearScene();

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -2,6 +2,7 @@
 using GameOverlay.Windows;
 using MapAssist.Helpers;
 using MapAssist.Settings;
+using MapAssist.Structs;
 using MapAssist.Types;
 using System;
 using System.Windows.Forms;
@@ -69,8 +70,7 @@ namespace MapAssist
                             var overlayHidden = !_show ||
                                 errorLoadingAreaData ||
                                 (MapAssistConfiguration.Loaded.RenderingConfiguration.ToggleViaInGameMap && !_gameData.MenuOpen.Map) ||
-                                (MapAssistConfiguration.Loaded.RenderingConfiguration.ToggleViaInGamePanels && _gameData.MenuPanelOpen > 0) ||
-                                (MapAssistConfiguration.Loaded.RenderingConfiguration.ToggleViaInGamePanels && _gameData.MenuOpen.EscMenu) ||
+                                (MapAssistConfiguration.Loaded.RenderingConfiguration.ToggleViaInGamePanels && _gameData.MenuOpen.IsAnyMenuOpen()) ||
                                 Array.Exists(MapAssistConfiguration.Loaded.HiddenAreas, area => area == _gameData.Area) ||
                                 _gameData.Area == Area.None ||
                                 gfx.Width == 1 ||

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -102,9 +102,7 @@ namespace MapAssist
                                 _compositor.DrawMonsterBar(gfx);
                             }
 
-                            if (!_gameData.MenuOpen.LoadingScreen) { 
-                                _compositor.DrawPlayerInfo(gfx);
-                            }
+                            _compositor.DrawPlayerInfo(gfx);
 
                             var gameInfoAnchor = GameInfoAnchor(MapAssistConfiguration.Loaded.GameInfo.Position);
                             var nextAnchor = _compositor.DrawGameInfo(gfx, gameInfoAnchor, e, errorLoadingAreaData);

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -102,7 +102,9 @@ namespace MapAssist
                                 _compositor.DrawMonsterBar(gfx);
                             }
 
-                            _compositor.DrawPlayerInfo(gfx);
+                            if (!_gameData.MenuOpen.LoadingScreen) { 
+                                _compositor.DrawPlayerInfo(gfx);
+                            }
 
                             var gameInfoAnchor = GameInfoAnchor(MapAssistConfiguration.Loaded.GameInfo.Position);
                             var nextAnchor = _compositor.DrawGameInfo(gfx, gameInfoAnchor, e, errorLoadingAreaData);

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -16,6 +16,8 @@ namespace MapAssist
 
         private readonly GraphicsWindow _window;
         private GameDataReader _gameDataReader;
+        private readonly BossKillCountRepository _bossKillCountRepository;
+        private readonly BossStateTracker _bossStateTracker;
         private GameData _gameData;
         private Compositor _compositor = new Compositor();
         private bool _show = true;
@@ -24,6 +26,8 @@ namespace MapAssist
         public Overlay()
         {
             _gameDataReader = new GameDataReader();
+            _bossKillCountRepository = new BossKillCountRepository();
+            _bossStateTracker = new BossStateTracker(_bossKillCountRepository);
 
             GameOverlay.TimerService.EnableHighPrecisionTimers();
 
@@ -88,7 +92,7 @@ namespace MapAssist
                                     break;
                             }
 
-                            _compositor.Init(gfx, _gameData, drawBounds);
+                            _compositor.Init(gfx, _gameData, _bossStateTracker, drawBounds);
 
                             if (!overlayHidden)
                             {
@@ -105,7 +109,7 @@ namespace MapAssist
                             _compositor.DrawPlayerInfo(gfx);
 
                             var gameInfoAnchor = GameInfoAnchor(MapAssistConfiguration.Loaded.GameInfo.Position);
-                            var nextAnchor = _compositor.DrawGameInfo(gfx, gameInfoAnchor, e, errorLoadingAreaData);
+                            var nextAnchor = _compositor.DrawGameInfo(gfx, gameInfoAnchor, e, errorLoadingAreaData, _bossKillCountRepository);
 
                             var itemLogAnchor = (MapAssistConfiguration.Loaded.ItemLog.Position == MapAssistConfiguration.Loaded.GameInfo.Position)
                                 ? nextAnchor.Add(0, GameInfoPadding())

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -183,6 +183,16 @@ namespace MapAssist.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        internal static System.Drawing.Bitmap BladesOfIce {
+            get {
+                object obj = ResourceManager.GetObject("BladesOfIce", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap Blaze {
             get {
                 object obj = ResourceManager.GetObject("Blaze", resourceCulture);
@@ -252,6 +262,16 @@ namespace MapAssist.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        internal static System.Drawing.Bitmap ClawsOfThunder {
+            get {
+                object obj = ResourceManager.GetObject("ClawsOfThunder", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap Cleansing {
             get {
                 object obj = ResourceManager.GetObject("Cleansing", resourceCulture);
@@ -275,6 +295,16 @@ namespace MapAssist.Properties {
         internal static System.Drawing.Bitmap CloakOfShadows {
             get {
                 object obj = ResourceManager.GetObject("CloakOfShadows", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap CobraStrike {
+            get {
+                object obj = ResourceManager.GetObject("CobraStrike", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -522,6 +552,16 @@ namespace MapAssist.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        internal static System.Drawing.Bitmap FistsOfFire {
+            get {
+                object obj = ResourceManager.GetObject("FistsOfFire", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap Frenzy {
             get {
                 object obj = ResourceManager.GetObject("Frenzy", resourceCulture);
@@ -668,21 +708,19 @@ namespace MapAssist.Properties {
         ///            font-family: Verdana;
         ///            background: black;
         ///            color: white;
+        ///            width: 100%;
+        ///            height: 100vh;
+        ///            margin: 0.5rem;
+        ///            overflow: hidden;
         ///            display: flex;
         ///            flex-direction: column;
         ///            align-items: center;
         ///        }
         ///
-        ///        #footer {
-        ///            font-size: xx-small;
+        ///        .footer {
+        ///            font-size: 0.7rem;
         ///            text-align: center;
-        ///            color: #606060;
-        ///        }
-        ///
-        ///        .header {
-        ///            margin: 2rem;
-        ///            font-size: 2rem;
-        ///      [rest of string was truncated]&quot;;.
+        ///            [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string InventoryExportTemplate {
             get {
@@ -813,6 +851,16 @@ namespace MapAssist.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        internal static System.Drawing.Bitmap PhoenixStrike {
+            get {
+                object obj = ResourceManager.GetObject("PhoenixStrike", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap Pierce {
             get {
                 object obj = ResourceManager.GetObject("Pierce", resourceCulture);
@@ -846,66 +894,6 @@ namespace MapAssist.Properties {
         internal static System.Drawing.Bitmap Prayer {
             get {
                 object obj = ResourceManager.GetObject("Prayer", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        internal static System.Drawing.Bitmap BladesOfIce {
-            get {
-                object obj = ResourceManager.GetObject("BladesOfIce", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        internal static System.Drawing.Bitmap TigerStrike {
-            get {
-                object obj = ResourceManager.GetObject("TigerStrike", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        internal static System.Drawing.Bitmap FistsOfFire {
-            get {
-                object obj = ResourceManager.GetObject("FistsOfFire", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        internal static System.Drawing.Bitmap ClawsOfThunder {
-            get {
-                object obj = ResourceManager.GetObject("ClawsOfThunder", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        internal static System.Drawing.Bitmap PhoenixStrike {
-            get {
-                object obj = ResourceManager.GetObject("PhoenixStrike", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        internal static System.Drawing.Bitmap CobraStrike {
-            get {
-                object obj = ResourceManager.GetObject("CobraStrike", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -1071,6 +1059,19 @@ namespace MapAssist.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Superunique	Name	Class	hcIdx	MonSound	Mod1	Mod2	Mod3	MinGrp	MaxGrp	AutoPos	Stacks	Replaceable	Utrans	Utrans(N)	Utrans(H)	TC	TC(N)	TC(H)	*eol
+        ///Bishibosh	Bishibosh	fallenshaman1	0		8	9	0	2	2	1	0		11	11	11	Act 1 Super A	Act 1 (N) Super A	Act 1 (H) Super A	0
+        ///Bonebreak	Bonebreak	skeleton1	1		5	8	0	5	5	1	0		5	5	5	Act 1 Super A	Act 1 (N) Super A	Act 1 (H) Super A	0
+        ///Coldcrow	Coldcrow	cr_archer1	2		18	0	0	4	4	1	0		18	18	18	Act 1 Super A	Act 1 (N) Super A	Act 1 (H) Super A	0
+        ///Rakanishu	Rakanishu	fallen2	3		17	6	0	8 [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string SuperUniques {
+            get {
+                return ResourceManager.GetString("SuperUniques", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap Teleport {
@@ -1116,6 +1117,16 @@ namespace MapAssist.Properties {
         internal static System.Drawing.Bitmap ThunderStorm {
             get {
                 object obj = ResourceManager.GetObject("ThunderStorm", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap TigerStrike {
+            get {
+                object obj = ResourceManager.GetObject("TigerStrike", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -59,7 +59,10 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root"
+    xmlns=""
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -456,5 +459,8 @@
   </data>
   <data name="QualityLevels" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\QualityLevels.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="SuperUniques" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\SuperUniques.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
 </root>

--- a/Resources/SuperUniques.txt
+++ b/Resources/SuperUniques.txt
@@ -1,0 +1,68 @@
+Superunique	Name	Class	hcIdx	MonSound	Mod1	Mod2	Mod3	MinGrp	MaxGrp	AutoPos	Stacks	Replaceable	Utrans	Utrans(N)	Utrans(H)	TC	TC(N)	TC(H)	*eol
+Bishibosh	Bishibosh	fallenshaman1	0		8	9	0	2	2	1	0		11	11	11	Act 1 Super A	Act 1 (N) Super A	Act 1 (H) Super A	0
+Bonebreak	Bonebreak	skeleton1	1		5	8	0	5	5	1	0		5	5	5	Act 1 Super A	Act 1 (N) Super A	Act 1 (H) Super A	0
+Coldcrow	Coldcrow	cr_archer1	2		18	0	0	4	4	1	0		18	18	18	Act 1 Super A	Act 1 (N) Super A	Act 1 (H) Super A	0
+Rakanishu	Rakanishu	fallen2	3		17	6	0	8	8	0	0	1	29	29	29	Act 1 Super B	Act 1 (N) Super B	Act 1 (H) Super B	0
+Treehead WoodFist	Treehead WoodFist	brute2	4		5	6	0	2	2	1	0	1	4	4	4	Act 1 Super B	Act 1 (N) Super B	Act 1 (H) Super B	0
+Griswold	Griswold	griswold	5		7	0	0	0	0	1	0	1	17	17	17	Griswold	Griswold (N)	Griswold (H)	0
+The Countess	The Countess	corruptrogue3	6	countess	9	0	0	6	6	1	0		16	16	16	Countess	Countess (N)	Countess (H)	0
+Pitspawn Fouldog	Pitspawn Fouldog	bighead2	7		7	18	0	4	4	1	0		31	31	31	Act 1 Super B	Act 1 (N) Super B	Act 1 (H) Super B	0
+Flamespike the Crawler	Flamespike the Crawler	quillrat4	8		9	7	0	6	6	1	0		16	16	16	Act 1 Unique C	Act 1 (N) Unique C	Act 1 (H) Unique C	0
+Boneash	Boneash	skmage_pois3	9		8	5	18	0	0	1	0		15	15	15	Act 1 Super C	Act 1 (N) Super C	Act 1 (H) Super C	0
+Radament	Radament	radament	10		6	0	0	3	3	1	0		30	30	30	Radament	Radament (N)	Radament (H)	0
+Bloodwitch the Wild	Bloodwitch the Wild	pantherwoman1	11		5	7	0	5	5	1	0		29	29	29	Act 2 Super A	Act 2 (N) Super A	Act 2 (H) Super A	0
+Fangskin	Fangskin	clawviper3	12		17	6	0	4	4	1	0		14	14	14	Act 2 Super B	Act 2 (N) Super B	Act 2 (H) Super B	0
+Beetleburst	Beetleburst	scarab2	13		8	0	0	3	3	1	0	1	13	13	13	Act 2 Super B	Act 2 (N) Super B	Act 2 (H) Super B	0
+Leatherarm	Leatherarm	mummy2	14		5	18	0	5	5	1	0		25	25	25	Act 2 Super A	Act 2 (N) Super A	Act 2 (H) Super A	0
+Coldworm the Burrower	Coldworm the Burrower	maggotqueen1	15		18	8	0	0	0	0	0		13	13	13	Act 2 Super B	Act 2 (N) Super B	Act 2 (H) Super B	0
+Fire Eye	Fire Eye	sandraider3	16		9	6	0	3	3	1	0		12	12	12	Act 2 Super B	Act 2 (N) Super B	Act 2 (H) Super B	0
+Dark Elder	Dark Elder	darkelder	17		6	8	0	4	4	1	0	1	27	27	27	Act 2 Super B	Act 2 (N) Super B	Act 2 (H) Super B	0
+The Summoner	The Summoner	summoner	18		5	6	0	0	0	1	0		26	26	26	Summoner	Summoner (N)	Summoner (H)	0
+Ancient Kaa the Soulless	Ancient Kaa the Soulless	unraveler3	19		25	5	17	3	3	1	0		11	11	11	Act 2 Super C	Act 2 (N) Super C	Act 2 (H) Super C	0
+The Smith	The Smith	smith	20	smith	5	0	0	0	0	1	0		26	26	26	Smith	Smith (N)	Smith (H)	0
+Web Mage the Burning	Web Mage the Burning	arach4	21		5	7	0	5	5	1	0		19	19	19	Act 3 Super A	Act 3 (N) Super A	Act 3 (H) Super A	0
+Witch Doctor Endugu	Witch Doctor Endugu	fetishshaman4	22		8	9	0	6	6	1	0		20	20	20	Act 3 Super B	Act 3 (N) Super B	Act 3 (H) Super B	0
+Stormtree	Stormtree	thornhulk3	23		6	17	0	4	4	1	0	1	35	35	35	Act 3 Super B	Act 3 (N) Super B	Act 3 (H) Super B	0
+Sarina the Battlemaid	Sarina the Battlemaid	corruptrogue5	24		6	27	0	9	9	1	0	1	36	36	36	Act 3 Super B	Act 3 (N) Super B	Act 3 (H) Super B	0
+Icehawk Riftwing	Icehawk Riftwing	batdemon3	25		18	26	0	7	7	1	0		21	21	21	Act 3 Super A	Act 3 (N) Super A	Act 3 (H) Super A	0
+Ismail Vilehand	Ismail Vilehand	councilmember1	26		6	7	0	2	2	1	0		36	36	36	Council	Council (N)	Council (H)	0
+Geleb Flamefinger	Geleb Flamefinger	councilmember2	27		5	9	0	2	2	1	0		37	37	37	Council	Council (N)	Council (H)	0
+Bremm Sparkfist	Bremm Sparkfist	councilmember3	28		30	17	0	2	2	1	0		22	22	22	Council	Council (N)	Council (H)	0
+Toorc Icefist	Toorc Icefist	councilmember1	29		18	28	0	0	0	1	0		23	23	23	Council	Council (N)	Council (H)	0
+Wyand Voidfinger	Wyand Voidfinger	councilmember2	30		25	26	0	0	0	1	0		38	38	38	Council	Council (N)	Council (H)	0
+Maffer Dragonhand	Maffer Dragonhand	councilmember3	31		5	6	0	0	0	1	0		23	23	23	Council	Council (N)	Council (H)	0
+Winged Death	Winged Death	megademon3	32		5	7	0	7	7	1	0		24	24	24	Act 4 Super A	Act 4 (N) Super A	Act 4 (H) Super A	0
+The Tormentor	The Tormentor	willowisp3	33		8	9	0	5	5	1	0		9	9	9	Act 4 Super A	Act 4 (N) Super A	Act 4 (H) Super A	0
+Taintbreeder	Taintbreeder	vilemother2	34		6	0	0	6	6	1	0		10	10	10	Act 4 Super A	Act 4 (N) Super A	Act 4 (H) Super A	0
+Riftwraith the Cannibal	Riftwraith the Cannibal	regurgitator2	35		18	26	0	8	8	1	0		25	25	25	Act 4 Super A	Act 4 (N) Super A	Act 4 (H) Super A	0
+Infector of Souls	Infector of Souls	megademon3	36		6	27	0	9	9	1	0		26	26	26	Act 4 Super B	Act 4 (N) Super B	Act 4 (H) Super B	0
+Lord De Seis	Lord De Seis	doomknight3	37		5	30	24	5	5	1	0		11	11	11	Act 4 Super C	Act 4 (N) Super C	Act 4 (H) Super C	0
+Grand Vizier of Chaos	Grand Vizier of Chaos	fingermage3	38		5	9	0	9	9	1	0		26	26	26	Act 4 Super B	Act 4 (N) Super B	Act 4 (H) Super B	0
+The Cow King	The Cow King	cowking	39		8	17	0	6	6	1	0		27	27	27	Cow King	Cow King (N)	Cow King (H)	0
+Corpsefire	Corpsefire	zombie1	40		27	0	0	5	5	1	0		25	25	25	Act 1 Super A	Act 1 (N) Super A	Act 1 (H) Super A	0
+The Feature Creep	The Feature Creep	hephasto	41	smithdemon	27	30	0	0	0	1	0		20	20	20	Haphesto	Haphesto (N)	Haphesto (H)	0
+Expansion																			0
+Siege Boss	Siege Boss	overseer1	42		5	0	0	0	0	0	1		7	7	7	Act 5 Super A	Act 5 (N) Super A	Act 5 (H) Super A	0
+Ancient Barbarian 1	Ancient Barbarian 1	ancientbarb1	43		0	0	0	0	0	0	1		25	25	25				0
+Ancient Barbarian 2	Ancient Barbarian 2	ancientbarb2	44		0	0	0	0	0	0	1		26	26	26				0
+Ancient Barbarian 3	Ancient Barbarian 3	ancientbarb3	45		0	0	0	0	0	0	1		11	11	11				0
+Axe Dweller	Axe Dweller	bloodlord3	46		8	9	0	2	2	0	0		20	20	20	Act 5 Super C	Act 5 (N) Super C	Act 5 (H) Super C	0
+Bonesaw Breaker	Bonesaw Breaker	reanimatedhorde2	47		5	8	0	5	5	0	0		35	35	35	Act 5 Super A	Act 5 (N) Super A	Act 5 (H) Super A	0
+Dac Farren	Dac Farren	imp3	48		18	0	0	4	4	0	0	1	36	36	36	Act 5 Super B	Act 5 (N) Super B	Act 5 (H) Super B	0
+Megaflow Rectifier	Megaflow Rectifier	minion1	49		1	6	0	8	8	0	0	1	21	21	21	Act 5 Super A	Act 5 (N) Super A	Act 5 (H) Super A	0
+Eyeback Unleashed	Eyeback Unleashed	deathmauler1	50		5	6	0	2	2	0	0		8	8	8	Act 5 Super A	Act 5 (N) Super A	Act 5 (H) Super A	0
+Threash Socket	Threash Socket	siegebeast3	51		7	0	0	0	0	0	0		37	37	37	Act 5 Super Cx	Act 5 (N) Super Cx	Act 5 (H) Super Cx	0
+Pindleskin	Pindleskin	reanimatedhorde5	52		9	0	0	6	6	0	0		22	22	22	Act 5 Super Cx	Act 5 (N) Super Cx	Act 5 (H) Super Cx	0
+Snapchip Shatter	Snapchip Shatter	frozenhorror1	53		7	18	0	4	4	0	0		23	23	23	Act 5 Super C	Act 5 (N) Super C	Act 5 (H) Super C	0
+Anodized Elite	Anodized Elite	succubus4	54		9	7	0	6	6	0	0		38	38	38	Act 5 Super C	Act 5 (N) Super C	Act 5 (H) Super C	0
+Vinvear Molech	Vinvear Molech	succubuswitch2	55		8	5	18	0	0	0	0		23	23	23	Act 5 Super A	Act 5 (N) Super A	Act 5 (H) Super A	0
+Sharp Tooth Sayer	Sharp Tooth Sayer	overseer3	56		6	0	0	3	3	0	0	1	24	24	24	Act 5 Super B	Act 5 (N) Super B	Act 5 (H) Super B	0
+Magma Torquer	Magma Torquer	imp5	57		5	7	0	5	5	0	0		9	9	9	Act 5 Super C	Act 5 (N) Super C	Act 5 (H) Super C	0
+Blaze Ripper	Blaze Ripper	deathmauler5	58		17	6	0	4	4	0	0		10	10	10	Act 5 Super C	Act 5 (N) Super C	Act 5 (H) Super C	0
+Frozenstein	Frozenstein	snowyeti4	59		18	25	0	5	6	0	0		19	19	19	Act 5 Super C	Act 5 (N) Super C	Act 5 (H) Super C	0
+Nihlathak Boss	Nihlathak	nihlathakboss	60		0	0	0	0	0	0	1		28	28	28	Nihlathak	Nihlathak (N)	Nihlathak (H)	0
+Baal Subject 1	Baal Subject 1	fallenshaman5	61		9	0	0	5	5	0	1		29	29	29	Act 5 Champ C	Act 5 (N) Champ C	Act 5 (H) Champ C	0
+Baal Subject 2	Baal Subject 2	unraveler5	62		23	0	0	3	3	0	1		21	21	21	Act 5 Champ C	Act 5 (N) Champ C	Act 5 (H) Champ C	0
+Baal Subject 3	Baal Subject 3	baalhighpriest	63		17	0	0	5	5	0	1		36	36	36	Act 5 Champ C	Act 5 (N) Champ C	Act 5 (H) Champ C	0
+Baal Subject 4	Baal Subject 4	venomlord	64		6	0	0	8	8	0	1		20	20	20	Act 5 Champ C	Act 5 (N) Champ C	Act 5 (H) Champ C	0
+Baal Subject 5	Baal Subject 5	baalminion1	65		27	0	0	5	5	0	1		20	20	20	Act 5 Champ C	Act 5 (N) Champ C	Act 5 (H) Champ C	0

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -47,7 +47,7 @@ namespace MapAssist.Settings
                 }
                 else
                 {
-                    foreach (var rule in Filters[itemClass])
+                    foreach (var rule in Filters[itemClass].ToArray())
                     {
                         assignRule(rule);
                     }

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -257,32 +257,27 @@ namespace MapAssist.Settings
 
         [YamlMember(Alias = "Max Quality Level")]
         public int? MaxQualityLevel { get; set; }
-    }
 
-    public static class ItemFilterExtensions
-    {
-        public static bool TargetsUnidItem(this ItemFilter rule)
+        public bool TargetsUnidItem()
         {
-            if (rule == null) return true;
-
-            foreach (var property in rule.GetType().GetProperties())
+            foreach (var property in GetType().GetProperties())
             {
                 if (property.Name == "Defense") continue;
 
                 var propType = property.PropertyType;
                 if (propType == typeof(object)) continue;
 
-                var propertyValue = rule.GetType().GetProperty(property.Name).GetValue(rule, null);
-                if (propertyValue != null && propType == typeof(int?) && (int)propertyValue > 0)
+                var propertyValue = GetType().GetProperty(property.Name).GetValue(this, null);
+                if (propertyValue != null && propType == typeof(int?) && (int)propertyValue != 0)
                 {
                     return false;
                 }
             }
 
-            if (rule.Skills.Where(subrule => subrule.Value != null).Count() > 0) return false;
-            if (rule.SkillCharges.Where(subrule => subrule.Value != null).Count() > 0) return false;
-            if (rule.ClassSkills.Where(subrule => subrule.Value != null).Count() > 0) return false;
-            if (rule.SkillTrees.Where(subrule => subrule.Value != null).Count() > 0) return false;
+            if (Skills.Where(subrule => subrule.Value != null).Count() > 0) return false;
+            if (SkillCharges.Where(subrule => subrule.Value != null).Count() > 0) return false;
+            if (ClassSkills.Where(subrule => subrule.Value != null).Count() > 0) return false;
+            if (SkillTrees.Where(subrule => subrule.Value != null).Count() > 0) return false;
 
             return true;
         }

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -53,15 +53,6 @@ namespace MapAssist.Settings
                     }
                 }
             }
-
-            // Validation for Enhanced Damage
-            foreach (var item in Filters.Where(kv => kv.Value != null && kv.Value.Exists(x => x.EnhancedDamage != null)))
-            {
-                if (item.Key != Item.Any && item.Key != Item.Jewel && item.Key != Item.ClassPaladinShields && Items.ItemClasses.FirstOrDefault(x => x.Value.Contains(item.Key)).Key != Item.ClassPaladinShields)
-                {
-                    throw new Exception($"Enhanced Damage was found on an ItemFilter rule for {item.Key}.\n\nIt is currently supported for Jewels and Paladin Shields.");
-                }
-            }
         }
     }
 
@@ -239,6 +230,9 @@ namespace MapAssist.Settings
 
         [YamlMember(Alias = "Enhanced Damage")]
         public int? EnhancedDamage { get; set; }
+
+        [YamlMember(Alias = "Enhanced Defense")]
+        public int? EnhancedDefense { get; set; }
 
         [YamlMember(Alias = "Min Area Level")]
         public int? MinAreaLevel { get; set; }

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -34,7 +34,7 @@ namespace MapAssist.Settings
 
         [YamlMember(Alias = "AuthorizedWindowTitles", ApplyNamingConventions = false)]
         public string[] AuthorizedWindowTitles { get; set; } = new string[] { };
-        
+
         [YamlMember(Alias = "RenderingConfiguration", ApplyNamingConventions = false)]
         public RenderingConfiguration RenderingConfiguration { get; set; }
 
@@ -157,25 +157,25 @@ namespace MapAssist.Settings
 
         [YamlMember(Alias = "MissileFireLarge", ApplyNamingConventions = false)]
         public IconRendering MissileFireLarge { get; set; }
-        
+
         [YamlMember(Alias = "MissileFireSmall", ApplyNamingConventions = false)]
         public IconRendering MissileFireSmall { get; set; }
-        
+
         [YamlMember(Alias = "MissileIceLarge", ApplyNamingConventions = false)]
         public IconRendering MissileIceLarge { get; set; }
-        
+
         [YamlMember(Alias = "MissileIceSmall", ApplyNamingConventions = false)]
         public IconRendering MissileIceSmall { get; set; }
-        
+
         [YamlMember(Alias = "MissileLightLarge", ApplyNamingConventions = false)]
         public IconRendering MissileLightLarge { get; set; }
-        
+
         [YamlMember(Alias = "MissileLightSmall", ApplyNamingConventions = false)]
         public IconRendering MissileLightSmall { get; set; }
-        
+
         [YamlMember(Alias = "MissilePoisonLarge", ApplyNamingConventions = false)]
         public IconRendering MissilePoisonLarge { get; set; }
-        
+
         [YamlMember(Alias = "MissilePoisonSmall", ApplyNamingConventions = false)]
         public IconRendering MissilePoisonSmall { get; set; }
 
@@ -290,11 +290,11 @@ public class GameInfoConfiguration
     [YamlMember(Alias = "ShowArea", ApplyNamingConventions = false)]
     public bool ShowArea { get; set; }
 
-    [YamlMember(Alias = "ShowDifficulty", ApplyNamingConventions = false)]
-    public bool ShowDifficulty { get; set; }
-
     [YamlMember(Alias = "ShowAreaLevel", ApplyNamingConventions = false)]
     public bool ShowAreaLevel { get; set; }
+
+    [YamlMember(Alias = "ShowDifficulty", ApplyNamingConventions = false)]
+    public bool ShowDifficulty { get; set; }
 
     [YamlMember(Alias = "ShowOverlayFPS", ApplyNamingConventions = false)]
     public bool ShowOverlayFPS { get; set; }
@@ -358,4 +358,22 @@ public class ItemLogConfiguration
 
     [YamlMember(Alias = "LabelTextShadow", ApplyNamingConventions = false)]
     public bool LabelTextShadow { get; set; }
+
+    [YamlMember(Alias = "SuperiorColor", ApplyNamingConventions = false)]
+    public Color SuperiorColor { get; set; }
+
+    [YamlMember(Alias = "MagicColor", ApplyNamingConventions = false)]
+    public Color MagicColor { get; set; }
+
+    [YamlMember(Alias = "RareColor", ApplyNamingConventions = false)]
+    public Color RareColor { get; set; }
+
+    [YamlMember(Alias = "SetColor", ApplyNamingConventions = false)]
+    public Color SetColor { get; set; }
+
+    [YamlMember(Alias = "UniqueColor", ApplyNamingConventions = false)]
+    public Color UniqueColor { get; set; }
+
+    [YamlMember(Alias = "CraftedColor", ApplyNamingConventions = false)]
+    public Color CraftedColor { get; set; }
 }

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -224,6 +224,18 @@ public class RenderingConfiguration
     [YamlMember(Alias = "BuffSize", ApplyNamingConventions = false)]
     public double BuffSize { get; set; }
 
+    [YamlMember(Alias = "ShowBuffBarBuffs", ApplyNamingConventions = false)]
+    public bool ShowBuffBarBuffs { get; set; }
+
+    [YamlMember(Alias = "ShowBuffBarAuras", ApplyNamingConventions = false)]
+    public bool ShowBuffBarAuras { get; set; }
+
+    [YamlMember(Alias = "ShowBuffBarPassives", ApplyNamingConventions = false)]
+    public bool ShowBuffBarPassives { get; set; }
+
+    [YamlMember(Alias = "ShowBuffBarDebuffs", ApplyNamingConventions = false)]
+    public bool ShowBuffBarDebuffs { get; set; }
+
     [YamlMember(Alias = "BuffAlertLowRes", ApplyNamingConventions = false)]
     public bool BuffAlertLowRes { get; set; }
 

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -316,6 +316,9 @@ public class GameInfoConfiguration
 
     [YamlMember(Alias = "ShowAreaTimer", ApplyNamingConventions = false)]
     public bool ShowAreaTimer { get; set; }
+    
+    [YamlMember(Alias = "ShowBossKillCount", ApplyNamingConventions = false)]
+    public bool ShowBossKillCount { get; set; }
 
     [YamlMember(Alias = "LabelFont", ApplyNamingConventions = false)]
     public string LabelFont { get; set; }

--- a/Structs/Items.cs
+++ b/Structs/Items.cs
@@ -27,6 +27,9 @@ namespace MapAssist.Structs
         [FieldOffset(0x0C)] public uint dwOwnerID; //which unitId owns this item (online only) - otherwise 0 = body, 1 = personal stash, 2 = sharedstash1, 3 = sharedstash2, 4 = sharedstash3, 5 = belt
         [FieldOffset(0x18)] public ItemFlags ItemFlags;
         [FieldOffset(0x34)] public uint uniqueOrSetId;
+        [FieldOffset(0x42)] public short RarePrefix;
+        [FieldOffset(0x44)] public short RareSuffix;
+        [FieldOffset(0x46)] public short AutoAffix;
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
         [FieldOffset(0x48)] public ushort[] Affixes;
         [FieldOffset(0x54)] public BodyLoc BodyLoc;

--- a/Structs/Menus.cs
+++ b/Structs/Menus.cs
@@ -1,5 +1,4 @@
 ﻿using MapAssist.Types;
-using System;
 using System.Runtime.InteropServices;
 
 namespace MapAssist.Structs
@@ -33,7 +32,9 @@ namespace MapAssist.Structs
         [FieldOffset(0x0D)] public bool Anvil; // Imbue and sockets
         [MarshalAs(UnmanagedType.U1)]
         [FieldOffset(0x0E)] public bool QuestLog;
-        //missing 4
+        //missing 3
+        [MarshalAs(UnmanagedType.U1)]
+        [FieldOffset(0x12)] public bool HasMercenary;
         [MarshalAs(UnmanagedType.U1)]
         [FieldOffset(0x13)] public bool Waypoint;
         //missing 1
@@ -64,5 +65,33 @@ namespace MapAssist.Structs
         [FieldOffset(0x01)] public bool IsItemTooltip;
         [FieldOffset(0x04)] public UnitType UnitType;
         [FieldOffset(0x08)] public uint UnitId;
+    }
+
+    public static class MenuDataExtensions
+    {
+        public static bool IsLeftMenuOpen(this MenuData menuData) =>
+            menuData.Character ||
+            menuData.NpcShop ||
+            menuData.Anvil ||
+            menuData.QuestLog ||
+            menuData.Waypoint ||
+            menuData.Party ||
+            menuData.Stash ||
+            menuData.Cube ||
+            menuData.MercenaryInventory ||
+            // Menus that cover the whole screen
+            menuData.EscMenu ||
+            menuData.Help;
+
+        public static bool IsRightMenuOpen(this MenuData menuData) =>
+            menuData.Inventory ||
+            menuData.SkillTree ||
+            // Menus that cover the whole screen
+            menuData.EscMenu ||
+            menuData.Help;
+
+        public static bool IsAnyMenuOpen(this MenuData menuData) =>
+            menuData.IsLeftMenuOpen() ||
+            menuData.IsRightMenuOpen();
     }
 }

--- a/Structs/Menus.cs
+++ b/Structs/Menus.cs
@@ -54,8 +54,6 @@ namespace MapAssist.Structs
         [FieldOffset(0x1D)] public bool Portraits;
         [MarshalAs(UnmanagedType.U1)]
         [FieldOffset(0x1E)] public bool MercenaryInventory;
-        [MarshalAs(UnmanagedType.U1)]
-        [FieldOffset(0x16C)] public bool LoadingScreen;
     }
 
     [StructLayout(LayoutKind.Explicit)]
@@ -92,12 +90,8 @@ namespace MapAssist.Structs
             menuData.EscMenu ||
             menuData.Help;
 
-        public static bool IsLoadingScreen(this MenuData menuData) =>
-            menuData.LoadingScreen;
-
         public static bool IsAnyMenuOpen(this MenuData menuData) =>
             menuData.IsLeftMenuOpen() ||
-            menuData.IsRightMenuOpen() ||
-            menuData.IsLoadingScreen();
+            menuData.IsRightMenuOpen();
     }
 }

--- a/Structs/Menus.cs
+++ b/Structs/Menus.cs
@@ -54,6 +54,8 @@ namespace MapAssist.Structs
         [FieldOffset(0x1D)] public bool Portraits;
         [MarshalAs(UnmanagedType.U1)]
         [FieldOffset(0x1E)] public bool MercenaryInventory;
+        [MarshalAs(UnmanagedType.U1)]
+        [FieldOffset(0x16C)] public bool LoadingScreen;
     }
 
     [StructLayout(LayoutKind.Explicit)]
@@ -90,8 +92,12 @@ namespace MapAssist.Structs
             menuData.EscMenu ||
             menuData.Help;
 
+        public static bool IsLoadingScreen(this MenuData menuData) =>
+            menuData.LoadingScreen;
+
         public static bool IsAnyMenuOpen(this MenuData menuData) =>
             menuData.IsLeftMenuOpen() ||
-            menuData.IsRightMenuOpen();
+            menuData.IsRightMenuOpen() ||
+            menuData.IsLoadingScreen();
     }
 }

--- a/Structs/Pet.cs
+++ b/Structs/Pet.cs
@@ -1,0 +1,15 @@
+﻿using MapAssist.Types;
+using System;
+using System.Runtime.InteropServices;
+
+namespace MapAssist.Structs
+{
+    [StructLayout(LayoutKind.Explicit)]
+    public struct Pet
+    {
+        [FieldOffset(0x00)] public readonly Npc TxtFileNo;
+        [FieldOffset(0x08)] public readonly uint UnitId;
+        [FieldOffset(0x0C)] public readonly uint OwnerId;
+        [FieldOffset(0x30)] public readonly IntPtr pNext;
+    }
+}

--- a/Structs/UnitAny.cs
+++ b/Structs/UnitAny.cs
@@ -57,20 +57,26 @@ namespace MapAssist.Structs
     }
 
     [StructLayout(LayoutKind.Explicit)]
+    public readonly struct StatListStruct
+    {
+        [FieldOffset(0x1C)] public readonly uint Flags;
+        [FieldOffset(0x30)] public readonly StatArrayStruct Stats;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
     public readonly struct StatArrayStruct
     {
         [FieldOffset(0x0)] public readonly IntPtr pFirstStat;
         [FieldOffset(0x8)] public readonly ulong Size;
-        [FieldOffset(0x10)] public readonly ulong Capacity;
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    public readonly struct StatListStruct
+    public readonly struct StatListExStruct
     {
-        [FieldOffset(0x8)] public readonly uint OwnerType;
-        [FieldOffset(0xC)] public readonly uint OwnerId;
-        [FieldOffset(0x1C)] public readonly uint Flags;
-        [FieldOffset(0x30)] public readonly StatArrayStruct BaseStats;
+        [FieldOffset(0x0)] public readonly StatListStruct BaseStats;
+        [FieldOffset(0x48)] public readonly IntPtr pPrevLink;
+        [FieldOffset(0x68)] public readonly IntPtr pLastList;
+        [FieldOffset(0x70)] public readonly IntPtr pMyStats;
         [FieldOffset(0x80)] public readonly StatArrayStruct Stats;
 
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]

--- a/Types/AreaData.cs
+++ b/Types/AreaData.cs
@@ -25,6 +25,7 @@ namespace MapAssist.Types
         public Rectangle ViewOutputRect;
         public Dictionary<Npc, Point[]> NPCs;
         public Dictionary<GameObject, Point[]> Objects;
+        public List<PointOfInterest> PointsOfInterest;
 
         public void CalcViewAreas(float angleRadians)
         {

--- a/Types/GameData.cs
+++ b/Types/GameData.cs
@@ -25,7 +25,6 @@ namespace MapAssist.Types
         public ItemLogEntry[] ItemLog;
         public Session Session;
         public Roster Roster;
-        public byte MenuPanelOpen;
         public MenuData MenuOpen;
         public Npc LastNpcInteracted;
         public int ProcessId;

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -96,7 +96,7 @@ namespace MapAssist.Types
 
             if (rule == null) return itemPrefix + itemBaseName;
 
-            if ((item.ItemData.ItemFlags & ItemFlags.IFLAG_ETHEREAL) == ItemFlags.IFLAG_ETHEREAL)
+            if (item.IsEthereal)
             {
                 itemPrefix += "[Eth] ";
             }
@@ -462,8 +462,7 @@ namespace MapAssist.Types
                 return Color.Empty;
             }
 
-            var isEth = (unit.ItemData.ItemFlags & ItemFlags.IFLAG_ETHEREAL) == ItemFlags.IFLAG_ETHEREAL;
-            if (isEth && fontColor == Color.White)
+            if (unit.IsEthereal && fontColor == Color.White)
             {
                 return ItemColors[ItemQuality.SUPERIOR];
             }

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -32,13 +32,18 @@ namespace MapAssist.Types
                 ItemUnitHashesSeen[processId].Add(item.HashString);
             }
 
-            if (item.IsPlayerOwned && item.IsIdentified)
+            ItemUnitIdsSeen[processId].Add(item.UnitId);
+
+            if (item.IsAnyPlayerHolding && item.IsIdentified)
             {
                 InventoryItemUnitIdsToSkip[processId].Add(item.UnitId);
                 ItemUnitIdsToSkip[processId].Add(item.UnitId);
-            }
 
-            ItemUnitIdsSeen[processId].Add(item.UnitId);
+                if (!item.IsPlayerOwned)
+                {
+                    return;
+                }
+            }
 
             var (logItem, rule) = LootFilter.Filter(item, areaLevel, playerLevel);
             if (!logItem) return;

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -9,6 +9,8 @@ namespace MapAssist.Types
 {
     public static class Items
     {
+        private static readonly NLog.Logger _log = NLog.LogManager.GetCurrentClassLogger();
+
         public static Dictionary<int, HashSet<string>> ItemUnitHashesSeen = new Dictionary<int, HashSet<string>>();
         public static Dictionary<int, HashSet<uint>> ItemUnitIdsSeen = new Dictionary<int, HashSet<uint>>();
         public static Dictionary<int, HashSet<uint>> ItemUnitIdsToSkip = new Dictionary<int, HashSet<uint>>();
@@ -48,13 +50,17 @@ namespace MapAssist.Types
 
             item.IsIdentifiedForLog = item.IsIdentified;
 
-            ItemLog[processId].Add(new ItemLogEntry()
+            var newLogEntry = new ItemLogEntry()
             {
                 ItemHashString = item.HashString,
                 UnitItem = item,
                 Rule = rule,
                 Area = area
-            });
+            };
+
+            ItemLog[processId].Add(newLogEntry);
+
+            _log.Info($"Added item to log: {newLogEntry.Text}");
         }
 
         public static bool CheckInventoryItem(UnitItem item, int processId) =>

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -2,7 +2,6 @@ using MapAssist.Helpers;
 using MapAssist.Settings;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using YamlDotNet.Serialization;
 
@@ -51,7 +50,6 @@ namespace MapAssist.Types
 
             ItemLog[processId].Add(new ItemLogEntry()
             {
-                Color = item.ItemBaseColor,
                 ItemHashString = item.HashString,
                 UnitItem = item,
                 Rule = rule,
@@ -418,27 +416,29 @@ namespace MapAssist.Types
 
             return prop.ToString();
         }
-        
+
         public static int? GetQualityLevel(UnitItem item)
-        { 
+        {
             string itemCode;
             if (!_ItemCodes.TryGetValue(item.TxtFileNo, out itemCode))
             {
                 return null;
             }
-            
+
             string namedCode;
             switch (item.ItemData.ItemQuality)
             {
                 case ItemQuality.UNIQUE:
-                    if(_UniqueFromCode.TryGetValue(itemCode, out namedCode) && namedCode != "Unique") {
+                    if (_UniqueFromCode.TryGetValue(itemCode, out namedCode) && namedCode != "Unique")
+                    {
                         itemCode = namedCode;
                     }
 
                     break;
 
                 case ItemQuality.SET:
-                    if(_SetFromCode.TryGetValue(itemCode, out namedCode) && namedCode != "Set") {
+                    if (_SetFromCode.TryGetValue(itemCode, out namedCode) && namedCode != "Set")
+                    {
                         itemCode = namedCode;
                     }
                     break;
@@ -451,47 +451,6 @@ namespace MapAssist.Types
             }
 
             return qualityLevel.qlvl;
-        }
-
-        public static Color GetItemBaseColor(UnitItem unit)
-        {
-            Color fontColor;
-            if (unit == null || !ItemColors.TryGetValue(unit.ItemData.ItemQuality, out fontColor))
-            {
-                // Invalid item quality
-                return Color.Empty;
-            }
-
-            if (unit.IsEthereal && fontColor == Color.White)
-            {
-                return ItemColors[ItemQuality.SUPERIOR];
-            }
-
-            if (unit.Stats.ContainsKey(Stats.Stat.NumSockets) && fontColor == Color.White)
-            {
-                return ItemColors[ItemQuality.SUPERIOR];
-            }
-
-            if (unit.TxtFileNo >= 610 && unit.TxtFileNo <= 642)
-            {
-                // Runes
-                return ItemColors[ItemQuality.CRAFT];
-            }
-
-            switch (unit.TxtFileNo)
-            {
-                case 647: // Key of Terror
-                case 648: // Key of Hate
-                case 649: // Key of Destruction
-                case 653: // Token of Absolution
-                case 654: // Twisted Essence of Suffering
-                case 655: // Charged Essense of Hatred
-                case 656: // Burning Essence of Terror
-                case 657: // Festering Essence of Destruction
-                    return ItemColors[ItemQuality.CRAFT];
-            }
-
-            return fontColor;
         }
 
         public static ItemTier GetItemTier(UnitItem item)
@@ -507,7 +466,7 @@ namespace MapAssist.Types
             var itemClass = itemClasses.First();
             if (itemClass.Key == Item.ClassCirclets) return ItemTier.NotApplicable;
 
-            return (ItemTier)(Array.IndexOf(itemClass.Value, item) * 3 / itemClass.Value.Length); // All items with each class (except circlets) come in equal amounts within each tier
+            return (ItemTier)(Array.IndexOf(itemClass.Value, item) * 3 / itemClass.Value.Length); // All items within each class (except circlets) come in equal amounts within each tier
         }
 
         public static int GetItemStat(UnitItem item, Stats.Stat stat)
@@ -695,18 +654,6 @@ namespace MapAssist.Types
             }
             return (0, 0, 0);
         }
-
-        public static readonly Dictionary<ItemQuality, Color> ItemColors = new Dictionary<ItemQuality, Color>()
-        {
-            {ItemQuality.INFERIOR, Color.White},
-            {ItemQuality.NORMAL, Color.White},
-            {ItemQuality.SUPERIOR, Color.Gray},
-            {ItemQuality.MAGIC, ColorTranslator.FromHtml("#4169E1")},
-            {ItemQuality.SET, ColorTranslator.FromHtml("#00FF00")},
-            {ItemQuality.RARE, ColorTranslator.FromHtml("#FFFF00")},
-            {ItemQuality.UNIQUE, ColorTranslator.FromHtml("#A59263")},
-            {ItemQuality.CRAFT, ColorTranslator.FromHtml("#FFAE00")},
-        };
 
         public static readonly Dictionary<uint, string> _SetFromId = new Dictionary<uint, string>()
         {
@@ -2418,7 +2365,6 @@ namespace MapAssist.Types
     public class ItemLogEntry
     {
         public string Text => Items.ItemLogDisplayName(UnitItem, Rule);
-        public Color Color { get; set; }
         public DateTime LogDate { get; private set; } = DateTime.Now;
         public bool ItemLogExpired => DateTime.Now.Subtract(LogDate).TotalSeconds > MapAssistConfiguration.Loaded.ItemLog.DisplayForSeconds;
         public string ItemHashString { get; set; }
@@ -2480,7 +2426,7 @@ namespace MapAssist.Types
         SET = 0x05, //0x05 Set
         RARE = 0x06, //0x06 Rare
         UNIQUE = 0x07, //0x07 Unique
-        CRAFT = 0x08, //0x08 Crafted
+        CRAFTED = 0x08, //0x08 Crafted
         TEMPERED = 0x09 //0x09 Tempered
     }
 

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -70,7 +70,7 @@ namespace MapAssist.Types
 
         public static bool CheckInventoryItem(UnitItem item, int processId) =>
             MapAssistConfiguration.Loaded.ItemLog.CheckItemOnIdentify &&
-            item.IsIdentified && item.IsPlayerOwned && !item.IsInSocket &&
+            item.IsIdentified && item.IsPlayerOwned && item.IsInInventory &&
             !InventoryItemUnitIdsToSkip[processId].Contains(item.UnitId);
 
         public static bool CheckDroppedItem(UnitItem item, int processId) =>

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -482,7 +482,9 @@ namespace MapAssist.Types
 
         public static int GetItemStat(UnitItem item, Stats.Stat stat)
         {
-            return item.Stats.TryGetValue(stat, out var statValue) ? statValue : 0;
+            return item.Stats.TryGetValue(stat, out var statValue) ? statValue :
+                item.StatsAdded != null && item.StatsAdded.TryGetValue(stat, out var statAddedValue) ? statAddedValue :
+                item.StaffMods != null && item.StaffMods.TryGetValue(stat, out var staffModValue) ? staffModValue : 0;
         }
 
         public static int GetItemStatShifted(UnitItem item, Stats.Stat stat)

--- a/Types/ItemsExport.cs
+++ b/Types/ItemsExport.cs
@@ -14,6 +14,7 @@ namespace MapAssist.Types
         public string baseName { get; set; }
         public string quality { get; set; }
         public string fullName { get; set; }
+        public string runeWord { get; set; }
         public bool ethereal { get; set; }
         public bool identified { get; set; }
         public int numSockets { get; set; }

--- a/Types/NPC.cs
+++ b/Types/NPC.cs
@@ -99,6 +99,13 @@ namespace MapAssist.Types
             Npc.Mephisto,
             Npc.Diablo,
             Npc.BaalCrab,
+            Npc.DiabloClone,
+            Npc.UberMephisto,
+            Npc.UberDiablo,
+            Npc.UberIzual,
+            Npc.Lilith,
+            Npc.UberDuriel,
+            Npc.UberBaal,
         };
 
         public static Dictionary<int, string> SuperUniques = ExcelDataLoader.Parse(Properties.Resources.SuperUniques).ToDictionary(x => int.Parse(x["hcIdx"]), x => x["Name"]);
@@ -931,7 +938,7 @@ namespace MapAssist.Types
 
         public static string Name(this Npc npc)
         {
-            var key = _npcLocalizationKeys.TryGetValue(npc, out var label) ? label : npc.ToString();
+            var key = _npcLocalizationKeys.TryGetValue(npc, out var label) ? label : npc.ToString().Replace("Uber", "").Replace("Clone", "");
 
             return LocalizedName(key);
         }

--- a/Types/NPC.cs
+++ b/Types/NPC.cs
@@ -1,6 +1,7 @@
 using MapAssist.Helpers;
 using MapAssist.Settings;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MapAssist.Types
 {
@@ -100,75 +101,7 @@ namespace MapAssist.Types
             Npc.BaalCrab,
         };
 
-        public static Dictionary<string, string> SuperUniques = new Dictionary<string, string>()
-        {
-            { "Corpsefire", "zombie1" },
-            { "Bishibosh", "fallenshaman1" },
-            { "Coldcrow", "cr_archer1" },
-            { "Bonebreak", "skeleton1" },
-            { "Rakanishu", "fallen2" },
-            { "Treehead WoodFist", "brute2" },
-            { "Griswold", "griswold" },
-            { "The Countess", "corruptrogue3" },
-            { "Pitspawn Fouldog", "bighead2" },
-            { "Flamespike the Crawler", "quillrat4" },
-            { "Boneash", "skmage_pois3" },
-            { "Radament", "radament" },
-            { "Bloodwitch the Wild", "pantherwoman1" },
-            { "Fangskin", "clawviper3" },
-            { "Beetleburst", "scarab2" },
-            { "Leatherarm", "mummy2" },
-            { "Coldworm the Burrower", "maggotqueen1" },
-            { "Fire Eye", "sandraider3" },
-            { "Dark Elder", "darkelder" },
-            { "The Summoner", "summoner" },
-            { "Ancient Kaa the Soulless", "unraveler3" },
-            { "The Smith", "smith" },
-            { "Web Mage the Burning", "arach4" },
-            { "Witch Doctor Endugu", "fetishshaman4" },
-            { "Stormtree", "thornhulk3" },
-            { "Sarina the Battlemaid", "corruptrogue5" },
-            { "Icehawk Riftwing", "batdemon3" },
-            //{ "Ismail Vilehand", "councilmember1" },
-            //{ "Geleb Flamefinger", "councilmember2" },
-            //{ "Bremm Sparkfist", "councilmember3" },
-            //{ "Toorc Icefist", "councilmember1" },
-            //{ "Wyand Voidfinger", "councilmember2" },
-            //{ "Maffer Dragonhand", "councilmember3" },
-            //{ "Winged Death", "megademon3" },
-            { "The Tormentor", "willowisp3" },
-            { "Taintbreeder", "vilemother2" },
-            { "Riftwraith the Cannibal", "regurgitator2" },
-            { "Infector of Souls", "megademon3" },
-            { "Lord De Seis", "doomknight3" },
-            { "Grand Vizier of Chaos", "fingermage3" },
-            { "The Cow King", "cowking" },
-            { "The Feature Creep", "hephasto" },
-            { "Siege Boss", "overseer1" },
-            { "Ancient Barbarian 1", "ancientbarb1" },
-            { "Ancient Barbarian 2", "ancientbarb2" },
-            { "Ancient Barbarian 3", "ancientbarb3" },
-            { "Axe Dweller", "bloodlord3" },
-            { "Bonesaw Breaker", "reanimatedhorde2" },
-            { "Dac Farren", "imp3" },
-            { "Megaflow Rectifier", "minion1" },
-            { "Eyeback Unleashed", "deathmauler1" },
-            { "Threash Socket", "siegebeast3" },
-            { "Pindleskin", "reanimatedhorde5" },
-            { "Snapchip Shatter", "frozenhorror1" },
-            { "Anodized Elite", "succubus4" },
-            { "Vinvear Molech", "succubuswitch2" },
-            { "Sharp Tooth Sayer", "overseer3" },
-            { "Magma Torquer", "imp5" },
-            { "Blaze Ripper", "deathmauler5" },
-            { "Frozenstein", "snowyeti4" },
-            { "Nihlathak", "nihlathakboss" },
-            { "Baal Subject 1", "fallenshaman5" },
-            { "Baal Subject 2", "unraveler5" },
-            { "Baal Subject 3", "baalhighpriest" },
-            { "Baal Subject 4", "venomlord" },
-            { "Baal Subject 5", "baalminion1" },
-        };
+        public static Dictionary<int, string> SuperUniques = ExcelDataLoader.Parse(Properties.Resources.SuperUniques).ToDictionary(x => int.Parse(x["hcIdx"]), x => x["Name"]);
     }
 
     public enum Npc : ushort

--- a/Types/Pets.cs
+++ b/Types/Pets.cs
@@ -1,0 +1,61 @@
+﻿using MapAssist.Helpers;
+using MapAssist.Interfaces;
+using MapAssist.Structs;
+using System;
+using System.Collections.Generic;
+
+namespace MapAssist.Types
+{
+    public class PetEntry
+    {
+        public IntPtr PtrUnit { get; set; }
+        public Pet Struct { get; set; }
+    
+        public uint UnitId => Struct.UnitId;
+        public uint OwnerId => Struct.OwnerId;
+        public bool IsMerc => new List<Npc> { Npc.Rogue2, Npc.Guard, Npc.IronWolf, Npc.Act5Hireling1Hand, Npc.Act5Hireling2Hand }.Contains(Struct.TxtFileNo);
+        public bool IsPlayerOwned { get; set; }
+    }
+
+    public class Pets : IUpdatable<Pets>
+    {
+        private readonly IntPtr _pFirst;
+        public List<PetEntry> List { get; } = new List<PetEntry>();
+
+        public Pets(IntPtr pFirst)
+        {
+            _pFirst = pFirst;
+            Update();
+        }
+
+        public Pets Update()
+        {
+            using (var processContext = GameManager.GetProcessContext())
+            {
+                var firstMember = processContext.Read<IntPtr>(_pFirst);
+                var entry = GetNewEntry(firstMember);
+                List.Add(entry);
+                while (entry.Struct.pNext != IntPtr.Zero)
+                {
+                    entry = GetNewEntry(entry.Struct.pNext);
+                    List.Add(entry);
+                }
+            }
+            return this;
+        }
+
+        private PetEntry GetNewEntry(IntPtr pAddress)
+        {
+            using (var processContext = GameManager.GetProcessContext())
+            {
+                var pet = processContext.Read<Pet>(pAddress);
+                var entry = new PetEntry
+                {
+                    PtrUnit = pAddress,
+                    Struct = pet
+                };
+                return entry;
+            }
+        }
+    }
+}

--- a/Types/Stats.cs
+++ b/Types/Stats.cs
@@ -9,16 +9,16 @@ namespace MapAssist.Types
     {
         public static readonly int StateCount = (int)Enum.GetValues(typeof(State)).Cast<State>().Max();
 
-        public static readonly Color DebuffColor = Color.FromArgb(255, 35, 55);
-        public static readonly Color PassiveColor = Color.FromArgb(180, 180, 180); //255, 35, 55 = red/debuff //180, 180, 180 = gray/passive
         public static readonly Color BuffColor = Color.FromArgb(0, 135, 235);
         public static readonly Color AuraColor = Color.FromArgb(245, 220, 80);
+        public static readonly Color PassiveColor = Color.FromArgb(180, 180, 180); //255, 35, 55 = red/debuff //180, 180, 180 = gray/passive
+        public static readonly Color DebuffColor = Color.FromArgb(255, 35, 55);
 
         public static Color StateColor(State state)
         {
-            if (PassiveStates.Contains(state)) { return PassiveColor; }
             if (BuffStates.Contains(state)) { return BuffColor; }
             if (AuraStates.Contains(state)) { return AuraColor; }
+            if (PassiveStates.Contains(state)) { return PassiveColor; }
             if (DebuffStates.Contains(state)) { return DebuffColor; }
             return Color.Gray;
         }

--- a/Types/Stats.cs
+++ b/Types/Stats.cs
@@ -533,7 +533,7 @@ namespace MapAssist.Types
             MaxDurability,
             ReplenishLife,
             MaxDurabilityPercent,
-            MaxHPPercent,
+            MaxLifePercent,
             MaxManaPercent,
             AttackerTakesDamage,
             GoldFind,

--- a/Types/Stats.cs
+++ b/Types/Stats.cs
@@ -473,7 +473,7 @@ namespace MapAssist.Types
             Experience,
             Gold,
             StashGold,
-            ArmorPercent,
+            EnhancedDefense,
             EnhancedDamageMax,
             EnhancedDamage,
             AttackRating,

--- a/Types/UnitAny.cs
+++ b/Types/UnitAny.cs
@@ -133,8 +133,6 @@ namespace MapAssist.Types
 
         public bool IsPlayer => Struct.UnitType == UnitType.Player && Struct.pAct != IntPtr.Zero;
 
-        public bool IsPlayerOwned => IsMerc && Stats.ContainsKey(Types.Stats.Stat.Strength); // This is ugly, but seems to work.
-
         public bool IsMonster
         {
             get
@@ -147,8 +145,6 @@ namespace MapAssist.Types
                 return true;
             }
         }
-
-        public bool IsMerc => new List<Npc> { Npc.Rogue2, Npc.Guard, Npc.IronWolf, Npc.Act5Hireling1Hand, Npc.Act5Hireling2Hand }.Contains((Npc)TxtFileNo);
 
         public bool IsCorpse => Struct.isCorpse && UnitId != GameMemory.PlayerUnit.UnitId && Area != Area.None;
 

--- a/Types/UnitAny.cs
+++ b/Types/UnitAny.cs
@@ -17,15 +17,22 @@ namespace MapAssist.Types
         public Point Position => new Point(X, Y);
         public float X => IsMovable ? Path.DynamicX : (float)Path.StaticX;
         public float Y => IsMovable ? Path.DynamicY : (float)Path.StaticY;
-        public StatListStruct StatsStruct { get; private set; }
-        public Dictionary<Stats.Stat, Dictionary<ushort, int>> StatLayers { get; private set; }
-        public Dictionary<Stats.Stat, int> Stats { get; private set; }
+        public StatListExStruct StatsStruct { get; private set; }
         public uint[] StateFlags { get; set; }
         public List<State> StateList { get; set; }
         public DateTime FoundTime { get; set; } = DateTime.Now;
         public bool IsHovered { get; set; } = false;
         public bool IsCached { get; set; } = false;
         private Path Path { get; set; }
+
+        public Dictionary<Stats.Stat, Dictionary<ushort, int>> StatLayers { get; private set; }
+        public Dictionary<Stats.Stat, int> Stats { get; private set; }
+        public Dictionary<Stats.Stat, Dictionary<ushort, int>> StatLayersBase { get; private set; }
+        public Dictionary<Stats.Stat, int> StatsBase { get; private set; }
+        public Dictionary<Stats.Stat, Dictionary<ushort, int>> StatLayersAdded { get; private set; }
+        public Dictionary<Stats.Stat, int> StatsAdded { get; private set; }
+        public Dictionary<Stats.Stat, Dictionary<ushort, int>> StaffModsLayers { get; private set; }
+        public Dictionary<Stats.Stat, int> StaffMods { get; private set; }
 
         public UnitAny(IntPtr ptrUnit)
         {
@@ -69,32 +76,23 @@ namespace MapAssist.Types
 
                         if (Struct.pStatsListEx != IntPtr.Zero)
                         {
-                            var stats = new Dictionary<Stats.Stat, int>();
-                            var statLayers = new Dictionary<Stats.Stat, Dictionary<ushort, int>>();
-
-                            StatsStruct = processContext.Read<StatListStruct>(Struct.pStatsListEx);
+                            StatsStruct = processContext.Read<StatListExStruct>(Struct.pStatsListEx);
                             StateFlags = StatsStruct.StateFlags;
 
-                            var statValues = processContext.Read<StatValue>(StatsStruct.Stats.pFirstStat, Convert.ToInt32(StatsStruct.Stats.Size));
-                            foreach (var stat in statValues)
+                            (Stats, StatLayers) = ReadStats(StatsStruct.Stats);
+                            (StatsBase, StatLayersBase) = ReadStats(StatsStruct.BaseStats.Stats);
+
+                            var addedStatsStruct = GetAddedStatsListPtr();
+                            if (addedStatsStruct.HasValue)
                             {
-                                if (statLayers.ContainsKey(stat.Stat))
+                                (StatsAdded, StatLayersAdded) = ReadStats(addedStatsStruct.Value.BaseStats.Stats);
+
+                                if (addedStatsStruct.Value.pPrevLink != IntPtr.Zero)
                                 {
-                                    if (stat.Layer == 0) continue;
-                                    if (!statLayers[stat.Stat].ContainsKey(stat.Layer))
-                                    {
-                                        statLayers[stat.Stat].Add(stat.Layer, stat.Value);
-                                    }
-                                }
-                                else
-                                {
-                                    stats.Add(stat.Stat, stat.Value);
-                                    statLayers.Add(stat.Stat, new Dictionary<ushort, int>() { { stat.Layer, stat.Value } });
+                                    var staffModsStruct = processContext.Read<StatListExStruct>(addedStatsStruct.Value.pPrevLink);
+                                    (StaffMods, StaffModsLayers) = ReadStats(staffModsStruct.BaseStats.Stats);
                                 }
                             }
-
-                            Stats = stats;
-                            StatLayers = statLayers;
                         }
 
                         if (GameMemory.cache.ContainsKey(UnitId)) IsCached = true;
@@ -105,6 +103,36 @@ namespace MapAssist.Types
             }
 
             return UpdateResult.InvalidUpdate;
+        }
+
+        protected (Dictionary<Stats.Stat, int>, Dictionary<Stats.Stat, Dictionary<ushort, int>>) ReadStats(StatArrayStruct statArray)
+        {
+            using (var processContext = GameManager.GetProcessContext())
+            {
+                var stats = new Dictionary<Stats.Stat, int>();
+                var statLayers = new Dictionary<Stats.Stat, Dictionary<ushort, int>>();
+
+                var statValues = processContext.Read<StatValue>(statArray.pFirstStat, Convert.ToInt32(statArray.Size));
+
+                foreach (var stat in statValues)
+                {
+                    if (statLayers.ContainsKey(stat.Stat))
+                    {
+                        if (stat.Layer == 0) continue;
+                        if (!statLayers[stat.Stat].ContainsKey(stat.Layer))
+                        {
+                            statLayers[stat.Stat].Add(stat.Layer, stat.Value);
+                        }
+                    }
+                    else
+                    {
+                        stats.Add(stat.Stat, stat.Value);
+                        statLayers.Add(stat.Stat, new Dictionary<ushort, int>() { { stat.Layer, stat.Value } });
+                    }
+                }
+
+                return (stats, statLayers);
+            }
         }
 
         protected List<State> GetStateList()
@@ -118,6 +146,45 @@ namespace MapAssist.Types
                 }
             }
             return stateList;
+        }
+
+        protected StatListExStruct? GetAddedStatsListPtr(int flags = 0x40)
+        {
+            using (var processContext = GameManager.GetProcessContext())
+            {
+                if ((StatsStruct.BaseStats.Flags & 0x80000000) == 0)
+                {
+                    return null;
+                }
+
+                StatListExStruct statList;
+                if (StatsStruct.pMyStats != IntPtr.Zero && (flags & 0x2000) != 0)
+                {
+                    statList = processContext.Read<StatListExStruct>(StatsStruct.pMyStats);
+                }
+                else if (StatsStruct.pLastList != IntPtr.Zero)
+                {
+                    statList = processContext.Read<StatListExStruct>(StatsStruct.pLastList);
+                }
+                else
+                {
+                    return null;
+                }
+
+                while ((flags & statList.BaseStats.Flags & 0xFFFFDFFF) == 0)
+                {
+                    if (StatsStruct.pPrevLink != IntPtr.Zero)
+                    {
+                        statList = processContext.Read<StatListExStruct>(statList.pPrevLink);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+
+                return statList;
+            }
         }
 
         private bool GetState(State state)

--- a/Types/UnitItem.cs
+++ b/Types/UnitItem.cs
@@ -1,4 +1,4 @@
-﻿using MapAssist.Helpers;
+using MapAssist.Helpers;
 using MapAssist.Settings;
 using MapAssist.Structs;
 using System;
@@ -43,6 +43,8 @@ namespace MapAssist.Types
         public void MarkInvalid() => _isInvalid = true;
 
         public bool IsValidItem => !_isInvalid && UnitId != uint.MaxValue;
+
+        public bool IsEthereal => (ItemData.ItemFlags & ItemFlags.IFLAG_ETHEREAL) == ItemFlags.IFLAG_ETHEREAL;
 
         public bool IsIdentified => ItemData.ItemQuality >= ItemQuality.MAGIC && (ItemData.ItemFlags & ItemFlags.IFLAG_IDENTIFIED) == ItemFlags.IFLAG_IDENTIFIED;
 

--- a/Types/UnitItem.cs
+++ b/Types/UnitItem.cs
@@ -2,6 +2,7 @@ using MapAssist.Helpers;
 using MapAssist.Settings;
 using MapAssist.Structs;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 
@@ -15,7 +16,7 @@ namespace MapAssist.Types
         public Item Item => (Item)TxtFileNo;
         public ItemMode ItemMode => (ItemMode)Struct.Mode;
         public string ItemBaseName => Items.GetItemBaseName(this);
-        public Color ItemBaseColor => Items.GetItemBaseColor(this);
+        public ItemQuality? MappedItemQuality { get; set; } = null;
 
         public UnitItem(IntPtr ptrUnit) : base(ptrUnit)
         {
@@ -30,6 +31,7 @@ namespace MapAssist.Types
                 using (var processContext = GameManager.GetProcessContext())
                 {
                     ItemData = processContext.Read<ItemData>(Struct.pUnitData);
+                    MappedItemQuality = GetMappedItemQuality();
                 }
             }
 
@@ -57,7 +59,7 @@ namespace MapAssist.Types
         public bool IsInStore => ItemModeMapped == ItemModeMapped.Vendor;
 
         public bool IsInSocket => ItemModeMapped == ItemModeMapped.Socket;
-        
+
         public ushort[] Prefixes => ItemData.Affixes.Take(3).ToArray();
 
         public ushort[] Suffixes => ItemData.Affixes.Skip(3).ToArray();
@@ -111,6 +113,80 @@ namespace MapAssist.Types
 
                 return ItemModeMapped.Unknown; // Items that appeared in the trade window before will appear here
             }
+        }
+
+        public Color ItemBaseColor
+        {
+            get
+            {
+                if (MappedItemQuality == null) return Color.Empty;
+
+                var ItemColors = new Dictionary<ItemQuality, Color>()
+                {
+                    {ItemQuality.INFERIOR, Color.White},
+                    {ItemQuality.NORMAL, Color.White},
+                    {ItemQuality.SUPERIOR, MapAssistConfiguration.Loaded.ItemLog.SuperiorColor},
+                    {ItemQuality.MAGIC, MapAssistConfiguration.Loaded.ItemLog.MagicColor},
+                    {ItemQuality.RARE, MapAssistConfiguration.Loaded.ItemLog.RareColor},
+                    {ItemQuality.SET, MapAssistConfiguration.Loaded.ItemLog.SetColor},
+                    {ItemQuality.UNIQUE, MapAssistConfiguration.Loaded.ItemLog.UniqueColor},
+                    {ItemQuality.CRAFTED, MapAssistConfiguration.Loaded.ItemLog.CraftedColor},
+                };
+
+                return ItemColors[(ItemQuality)MappedItemQuality];
+            }
+        }
+
+        private ItemQuality? GetMappedItemQuality()
+        {
+            var ItemQualities = new List<ItemQuality>()
+            {
+                ItemQuality.INFERIOR,
+                ItemQuality.NORMAL,
+                ItemQuality.SUPERIOR,
+                ItemQuality.MAGIC,
+                ItemQuality.RARE,
+                ItemQuality.SET,
+                ItemQuality.UNIQUE,
+                ItemQuality.CRAFTED,
+            };
+
+            if (!ItemQualities.Contains(ItemData.ItemQuality))
+            {
+                // Invalid item quality
+                return null;
+            }
+
+            if (IsEthereal && ItemData.ItemQuality <= ItemQuality.NORMAL)
+            {
+                return ItemQuality.SUPERIOR;
+            }
+
+            if (Stats.ContainsKey(Types.Stats.Stat.NumSockets) && ItemData.ItemQuality <= ItemQuality.NORMAL)
+            {
+                return ItemQuality.SUPERIOR;
+            }
+
+            if (TxtFileNo >= 610 && TxtFileNo <= 642)
+            {
+                // Runes
+                return ItemQuality.CRAFTED;
+            }
+
+            switch (TxtFileNo)
+            {
+                case 647: // Key of Terror
+                case 648: // Key of Hate
+                case 649: // Key of Destruction
+                case 653: // Token of Absolution
+                case 654: // Twisted Essence of Suffering
+                case 655: // Charged Essense of Hatred
+                case 656: // Burning Essence of Terror
+                case 657: // Festering Essence of Destruction
+                    return ItemQuality.CRAFTED;
+            }
+
+            return ItemData.ItemQuality;
         }
 
         public override string HashString => Item + "/" + Position.X + "/" + Position.Y;

--- a/Types/UnitItem.cs
+++ b/Types/UnitItem.cs
@@ -56,6 +56,8 @@ namespace MapAssist.Types
 
         public bool IsDropped => ItemModeMapped == ItemModeMapped.Ground;
 
+        public bool IsInInventory => ItemModeMapped == ItemModeMapped.Inventory;
+
         public bool IsInStore => ItemModeMapped == ItemModeMapped.Vendor;
 
         public bool IsInSocket => ItemModeMapped == ItemModeMapped.Socket;

--- a/Types/UnitItem.cs
+++ b/Types/UnitItem.cs
@@ -11,7 +11,7 @@ namespace MapAssist.Types
     public class UnitItem : UnitAny
     {
         public ItemData ItemData { get; private set; }
-        public new bool IsPlayerOwned { get; set; } = false;
+        public bool IsPlayerOwned { get; set; } = false;
         public Npc VendorOwner { get; set; } = Npc.Invalid;
         public Item Item => (Item)TxtFileNo;
         public ItemMode ItemMode => (ItemMode)Struct.Mode;

--- a/Types/UnitMonster.cs
+++ b/Types/UnitMonster.cs
@@ -34,6 +34,9 @@ namespace MapAssist.Types
             return null;
         }
 
+        public bool IsSuperUnique => (MonsterData.MonsterType & MonsterTypeFlags.SuperUnique) == MonsterTypeFlags.SuperUnique || Npc == Npc.Summoner; // Summoner seems to be an odd exception
+        public string SuperUniqueName => Npc == Npc.Summoner ? "The Summoner" : NPC.SuperUniques[MonsterData.BossLineID];
+
         private List<Resist> GetImmunities()
         {
             Stats.TryGetValue(Types.Stats.Stat.DamageReduced, out var resistanceDamage);

--- a/Types/UnitMonster.cs
+++ b/Types/UnitMonster.cs
@@ -11,6 +11,7 @@ namespace MapAssist.Types
         public MonStats MonsterStats { get; private set; }
         public List<Resist> Immunities { get; set; }
         public Npc Npc => (Npc)TxtFileNo;
+        public PetEntry PetEntry { get; set; }
 
         public UnitMonster(IntPtr ptrUnit) : base(ptrUnit)
         {
@@ -35,7 +36,12 @@ namespace MapAssist.Types
         }
 
         public bool IsSuperUnique => (MonsterData.MonsterType & MonsterTypeFlags.SuperUnique) == MonsterTypeFlags.SuperUnique || Npc == Npc.Summoner; // Summoner seems to be an odd exception
+        
         public string SuperUniqueName => Npc == Npc.Summoner ? "The Summoner" : NPC.SuperUniques[MonsterData.BossLineID];
+
+        public bool IsMerc => PetEntry != null && PetEntry.IsMerc;
+
+        public bool IsPlayerOwned => PetEntry != null && PetEntry.IsPlayerOwned;
 
         private List<Resist> GetImmunities()
         {


### PR DESCRIPTION
Added an act boss tracker. Tracking Andy, Duriel, Meph, Diablo and Baal kills.
Kill count is persisted in a LiteDB.
Hooked on the Compositor's GetActiveMonsters method to track a boss' state.

![image](https://user-images.githubusercontent.com/12453002/169937593-f08c4862-3bba-4e29-b2ab-aa2d8c14a482.png)
![image](https://user-images.githubusercontent.com/12453002/169937794-bef0b466-9a6c-4d87-9f73-e45681bf01db.png)

