### PR TITLE
Caching ItemLogDisplayName to optimize performance

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -1018,6 +1018,7 @@ namespace MapAssist.Helpers
 
             // Setup
             var fontSize = gfx.ScaleFontSize((float)MapAssistConfiguration.Loaded.ItemLog.LabelFontSize);
+            var font = CreateFont(gfx, MapAssistConfiguration.Loaded.ItemLog.LabelFont, fontSize);
             var lineHeight = gfx.LineHeight(fontSize);
             var textShadow = MapAssistConfiguration.Loaded.ItemLog.LabelTextShadow;
             var shadowBrush = CreateSolidBrush(gfx, Color.Black, 0.6f);
@@ -1028,11 +1029,10 @@ namespace MapAssist.Helpers
             for (var i = 0; i < itemsToShow.Length; i++)
             {
                 var item = itemsToShow[i];
-
-                var font = CreateFont(gfx, MapAssistConfiguration.Loaded.ItemLog.LabelFont, fontSize);
+                var itemText = item.Text;
                 var position = anchor.Add(0, i * lineHeight);
                 var brush = CreateSolidBrush(gfx, item.UnitItem.ItemBaseColor, 1);
-                var stringSize = gfx.MeasureString(font, item.Text);
+                var stringSize = gfx.MeasureString(font, itemText);
 
                 if (MapAssistConfiguration.Loaded.ItemLog.Position == GameInfoPosition.TopRight)
                 {
@@ -1069,9 +1069,9 @@ namespace MapAssist.Helpers
 
                 if (textShadow)
                 {
-                    gfx.DrawText(font, shadowBrush, position.X + shadowOffset, position.Y + shadowOffset, item.Text);
+                    gfx.DrawText(font, shadowBrush, position.X + shadowOffset, position.Y + shadowOffset, itemText);
                 }
-                gfx.DrawText(font, brush, position, item.Text);
+                gfx.DrawText(font, brush, position, itemText);
 
                 if (MapAssistConfiguration.Loaded.ItemLog.ShowDirectionToItem && item.Area == _gameData.Area && item.UnitItem.IsDropped)
                 {

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -461,6 +461,7 @@ namespace MapAssist.Helpers
                 Items.InventoryItemUnitIdsToSkip.Add(_currentProcessId, new HashSet<uint>());
                 Items.ItemVendors.Add(_currentProcessId, new Dictionary<uint, Npc>());
                 Items.ItemLog.Add(_currentProcessId, new List<ItemLogEntry>());
+                Items.ItemDisplayNames.Add(_currentProcessId, new Dictionary<uint, string>());
             }
             else
             {
@@ -470,6 +471,7 @@ namespace MapAssist.Helpers
                 Items.InventoryItemUnitIdsToSkip[_currentProcessId].Clear();
                 Items.ItemVendors[_currentProcessId].Clear();
                 Items.ItemLog[_currentProcessId].Clear();
+                Items.ItemDisplayNames[_currentProcessId].Clear();
             }
 
             if (!Corpses.ContainsKey(_currentProcessId))


### PR DESCRIPTION
I noticed as more item log entries show up on the screen the overlay FPS starts to degrade until the item log entries expire.

I've added caching for `ItemLogDisplayName` using the process Id and item UnitId so we'll cache the results of the method and continue serving the cached text instead of parsing rules/stats every frame to generate the same text again.

When I was testing the DebugItemFilter and doing vendor trades, I could get as low as 8 fps from the overlay when the item log was filling up the screen (extreme end of performance degrading)

With these changes doing the same test results in around 40 fps when the item log is filling up the screen from vendor trades.