### PR TITLE
Hide opened Armor/Weapon Racks

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -299,12 +299,9 @@ namespace MapAssist.Helpers
                     continue;
                 }
 
-                if (gameObject.IsArmorWeapRack)
+                if (gameObject.IsArmorWeapRack && MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack.CanDrawIcon())
                 {
-                    if (MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack.CanDrawIcon())
-                    {
-                        drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack, gameObject.Position));
-                    }
+                    drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack, gameObject.Position));
                 }
 
                 if (gameObject.IsChest)

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -299,9 +299,17 @@ namespace MapAssist.Helpers
                     continue;
                 }
 
+                if (gameObject.IsArmorWeapRack)
+                {
+                    if (MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack.CanDrawIcon())
+                    {
+                        drawPoiIcons.Add((MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack, gameObject.Position));
+                    }
+                }
+
                 if (gameObject.IsChest)
                 {
-                    if ((gameObject.ObjectData.InteractType & ((byte)Chest.InteractFlags.Trap)) != ((byte)Chest.InteractFlags.None))
+                    if ((gameObject.ObjectData.InteractType & (byte)Chest.InteractFlags.Trap) == (byte)Chest.InteractFlags.Trap)
                     {
                         if (MapAssistConfiguration.Loaded.MapConfiguration.TrappedChest.CanDrawIcon())
                         {
@@ -309,7 +317,7 @@ namespace MapAssist.Helpers
                         }
                     }
 
-                    if ((gameObject.ObjectData.InteractType & ((byte)Chest.InteractFlags.Locked)) != ((byte)Chest.InteractFlags.None))
+                    if ((gameObject.ObjectData.InteractType & (byte)Chest.InteractFlags.Locked) == (byte)Chest.InteractFlags.Locked)
                     {
                         if (MapAssistConfiguration.Loaded.MapConfiguration.LockedChest.CanDrawIcon())
                         {

--- a/Helpers/PointOfInterestHandler.cs
+++ b/Helpers/PointOfInterestHandler.cs
@@ -59,29 +59,6 @@ namespace MapAssist.Helpers
             },
         };
 
-        private static readonly HashSet<GameObject> SuperChests = new HashSet<GameObject>
-        {
-            GameObject.GoodChest,
-            GameObject.SparklyChest,
-            GameObject.ArcaneLargeChestLeft,
-            GameObject.ArcaneLargeChestRight,
-            GameObject.ArcaneSmallChestLeft,
-            GameObject.ArcaneSmallChestRight,
-            GameObject.ExpansionSpecialChest,
-        };
-
-        private static readonly HashSet<GameObject> ArmorWeapRacks = new HashSet<GameObject>
-        {
-            GameObject.ExpansionArmorStandRight,
-            GameObject.ExpansionArmorStandLeft,
-            GameObject.ArmorStandRight,
-            GameObject.ArmorStandLeft,
-            GameObject.ExpansionWeaponRackRight,
-            GameObject.ExpansionWeaponRackLeft,
-            GameObject.WeaponRackRight,
-            GameObject.WeaponRackLeft,
-        };
-
         private static readonly HashSet<GameObject> Shrines = new HashSet<GameObject>
         {
             GameObject.Shrine,
@@ -546,7 +523,7 @@ namespace MapAssist.Helpers
                     }
                 }
                 // Super Chest
-                else if (SuperChests.Contains(obj))
+                else if (Chest.SuperChests.Contains(obj))
                 {
                     foreach (var point in points)
                     {
@@ -557,21 +534,6 @@ namespace MapAssist.Helpers
                             Position = point,
                             RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.SuperChest,
                             Type = PoiType.SuperChest
-                        });
-                    }
-                }
-                // Armor Stands & Weapon Racks
-                else if (ArmorWeapRacks.Contains(obj))
-                {
-                    foreach (var point in points)
-                    {
-                        pointsOfInterest.Add(new PointOfInterest
-                        {
-                            Area = areaData.Area,
-                            Label = obj.ToString(),
-                            Position = point,
-                            RenderingSettings = MapAssistConfiguration.Loaded.MapConfiguration.ArmorWeapRack,
-                            Type = PoiType.ArmorWeapRack
                         });
                     }
                 }

--- a/Types/Chest.cs
+++ b/Types/Chest.cs
@@ -145,6 +145,29 @@ namespace MapAssist.Types
             GameObject.NotSoGoodChest
         };
 
+        public static readonly HashSet<GameObject> SuperChests = new HashSet<GameObject>
+        {
+            GameObject.GoodChest,
+            GameObject.SparklyChest,
+            GameObject.ArcaneLargeChestLeft,
+            GameObject.ArcaneLargeChestRight,
+            GameObject.ArcaneSmallChestLeft,
+            GameObject.ArcaneSmallChestRight,
+            GameObject.ExpansionSpecialChest,
+        };
+
+        public static readonly HashSet<GameObject> ArmorWeapRacks = new HashSet<GameObject>
+        {
+            GameObject.ExpansionArmorStandRight,
+            GameObject.ExpansionArmorStandLeft,
+            GameObject.ArmorStandRight,
+            GameObject.ArmorStandLeft,
+            GameObject.ExpansionWeaponRackRight,
+            GameObject.ExpansionWeaponRackLeft,
+            GameObject.WeaponRackRight,
+            GameObject.WeaponRackLeft,
+        };
+
         [Flags]
         public enum InteractFlags
         {

--- a/Types/UnitObject.cs
+++ b/Types/UnitObject.cs
@@ -49,6 +49,8 @@ namespace MapAssist.Types
 
         public bool IsChest => UnitType == UnitType.Object && ObjectData.pObjectTxt != IntPtr.Zero && Struct.Mode == 0 && Chest.NormalChests.Contains(GameObject);
 
+        public bool IsArmorWeapRack => UnitType == UnitType.Object && ObjectData.pObjectTxt != IntPtr.Zero && Struct.Mode == 0 && Chest.ArmorWeapRacks.Contains(GameObject);
+
         public override string HashString => GameObject + "/" + Position.X + "/" + Position.Y;
     }
 }


### PR DESCRIPTION
Similar to chests, hides the map icon for Armor/Weapon Racks once clicked/opened