### PR TITLE
Prevent duplicate yaml keys

### DIFF
--- a/Helpers/YamlConverters.cs
+++ b/Helpers/YamlConverters.cs
@@ -214,11 +214,8 @@ namespace MapAssist.Helpers
         {
             if (parser.TryConsume<Scalar>(out var scalar))
             {
-                if (Enum.TryParse("Class" + scalar.Value.Replace(" ", "").Replace("-", ""), true, out Item itemClass))
-                {
-                    return itemClass;
-                }
-                else if (Enum.TryParse(scalar.Value.Replace(" ", "").Replace("-", ""), true, out Item item))
+                var item = Items.ParseFromString(scalar.Value);
+                if (item != null)
                 {
                     return item;
                 }

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -682,6 +682,20 @@ namespace MapAssist.Types
             return (0, 0, 0);
         }
 
+        public static Item? ParseFromString(string text)
+        {
+            if (Enum.TryParse("Class" + text.Replace(" ", "").Replace("-", ""), true, out Item itemClass))
+            {
+                return itemClass;
+            }
+            else if (Enum.TryParse(text.Replace(" ", "").Replace("-", ""), true, out Item item))
+            {
+                return item;
+            }
+
+            return null;
+        }
+
         public static readonly Dictionary<uint, string> _SetFromId = new Dictionary<uint, string>()
         {
             {0, "Civerb's Ward"},


### PR DESCRIPTION
- Checks for duplicate yaml keys. The approach doesn't use yamldotnet because it doesn't support duplicate key prevention.
- Also remove extra intermediate catch blocks so they all bubble up back to Program.cs for a more comprehensive messagebox and log entry