### PR TITLE
Adjust map positioning for TopRight and TopLeft options

### DIFF
--- a/Overlay.cs
+++ b/Overlay.cs
@@ -79,16 +79,18 @@ namespace MapAssist
                                 gfx.Height == 1;
 
                             var size = MapAssistConfiguration.Loaded.RenderingConfiguration.Size;
+                            var height = MapAssistConfiguration.Loaded.RenderingConfiguration.OverlayMode ? size / 2 : size;
 
                             var drawBounds = new Rectangle(0, 0, gfx.Width, gfx.Height * 0.78f);
                             switch (MapAssistConfiguration.Loaded.RenderingConfiguration.Position)
                             {
                                 case MapPosition.TopLeft:
-                                    drawBounds = new Rectangle(PlayerIconWidth() + 40, PlayerIconWidth() + 100, 0, PlayerIconWidth() + 100 + size);
+                                    drawBounds = new Rectangle(PlayerIconWidth() + 40, PlayerIconWidth() + 100, 0, PlayerIconWidth() + 100 + height);
                                     break;
 
                                 case MapPosition.TopRight:
-                                    drawBounds = new Rectangle(0, 100, gfx.Width, 100 + size);
+                                    var drawWidth = MapAssistConfiguration.Loaded.RenderingConfiguration.OverlayMode ? gfx.Width : gfx.Width - GameInfoRightMargin();
+                                    drawBounds = new Rectangle(0, PlayerIconWidth() + 100, drawWidth, PlayerIconWidth() + 100 + height);
                                     break;
                             }
 
@@ -113,7 +115,7 @@ namespace MapAssist
 
                             var itemLogAnchor = (MapAssistConfiguration.Loaded.ItemLog.Position == MapAssistConfiguration.Loaded.GameInfo.Position)
                                 ? nextAnchor.Add(0, GameInfoPadding())
-                                : GameInfoAnchor(MapAssistConfiguration.Loaded.ItemLog.Position);
+                                : gameInfoAnchor;
                             _compositor.DrawItemLog(gfx, itemLogAnchor);
                         }
                     }
@@ -231,6 +233,11 @@ namespace MapAssist
             return rect.Height / 100f;
         }
 
+        private float GameInfoRightMargin()
+        {
+            return _window.Width / 60f;
+        }
+
         private Point GameInfoAnchor(GameInfoPosition position)
         {
             switch (position)
@@ -240,9 +247,8 @@ namespace MapAssist
                     return new Point(PlayerIconWidth() + margin, PlayerIconWidth() + margin);
 
                 case GameInfoPosition.TopRight:
-                    var rightMargin = _window.Width / 60f;
                     var topMargin = _window.Height / 35f;
-                    return new Point(_window.Width - rightMargin, topMargin);
+                    return new Point(_window.Width - GameInfoRightMargin(), topMargin);
             }
             return new Point();
         }

--- a/Types/Area.cs
+++ b/Types/Area.cs
@@ -823,7 +823,7 @@ namespace MapAssist.Types
 
         public static bool RequiresStitching(this Area area)
         {
-            return StitchedAreas.Contains(area);
+            return MapAssistConfiguration.Loaded.RenderingConfiguration.OverlayMode && StitchedAreas.Contains(area);
         }
         public static bool IsTown(this Area area)
         {


### PR DESCRIPTION
Took a shot at adjusting the `TopRight` and `TopLeft` map positions for both overlay modes.

I made it so these map positions will draw at half height to mimic the in-game mini map for our Overlay mode.  For non-overlay mode I turned off area stitching and adjusted the drawing bounds/scaling a bit.  Lots of other little fine tuning for zooming in/out with hotkeys too when these map positions are used.

Overlay mode (draw bounds height adjusted):
![1](https://user-images.githubusercontent.com/10291543/170917011-5276cff6-e2c3-44fd-b797-23c6d80b738f.png)
![2](https://user-images.githubusercontent.com/10291543/170917013-71ad4717-d847-414c-9715-3f8300f7b91b.png)

Non-overlay mode (average size maps)
![3](https://user-images.githubusercontent.com/10291543/170917017-3f4ca8e0-dbeb-41bb-8719-169b4318b87f.png)
![4](https://user-images.githubusercontent.com/10291543/170917018-03618d59-e283-47a9-bcdd-b0f9a29fc55f.png)

Non-overlay mode (large maps are constrained to the configured Map Size)
![5](https://user-images.githubusercontent.com/10291543/170918466-9df35045-0efb-4010-bc80-a9a4b268b919.png)
![6](https://user-images.githubusercontent.com/10291543/170918473-c430683b-b4b7-4882-841f-1517718d77f9.png)

Non-overlay mode (small maps are prevented from upscaling too much)
![7](https://user-images.githubusercontent.com/10291543/170918673-90699539-06b3-4c3e-ae94-33324b3d100a.png)
![8](https://user-images.githubusercontent.com/10291543/170918674-1f65451c-cabe-4488-979c-84853004c6e3.png)

