### PR TITLE
Pentagram icon

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -1312,6 +1312,12 @@ namespace MapAssist.Helpers
                             gfx.DrawGeometry(geo, outlineBrush, rendering.IconThickness);
                         }
 
+                        if (rendering.IconShape == Shape.Pentagram && (rendering.IconColor.A > 0 || rendering.IconOutlineColor.A > 0))
+                        {
+                            var brush = rendering.IconOutlineColor.A > 0 ? outlineBrush : fillBrush;
+                            gfx.DrawEllipse(brush, position, rendering.IconSize * scaleWidth / 2 + rendering.IconThickness, rendering.IconSize * _scaleHeight / 2 + rendering.IconThickness, rendering.IconThickness); // Divide by 2 because the parameter requires a radius
+                        }
+
                         break;
                 }
             }
@@ -1533,6 +1539,17 @@ namespace MapAssist.Helpers
                         new Point(0.4f, 0.40f),
                         new Point(0.50f, 0.50f),
                     }.Select(point => point.Multiply(render.IconSize).Subtract(render.IconSize / 2f).Multiply(scaleWidth, scaleWidth)).ToArray();
+
+                case Shape.Pentagram:
+                    return new Point[]
+                    {
+                        new Point(0.50f, 0f),
+                        new Point(0.22f, 0.9f),
+                        new Point(0.96f, 0.38f),
+                        new Point(0.04f, 0.38f),
+                        new Point(0.78f, 0.9f),
+                        new Point(0.50f, 0f),
+                    }.Select(point => point.Multiply(render.IconSize).Subtract(render.IconSize / 2).Rotate(_rotateRadians).Multiply(scaleWidth, _scaleHeight)).ToArray();
             }
 
             return new Point[]

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -1543,13 +1543,13 @@ namespace MapAssist.Helpers
                 case Shape.Pentagram:
                     return new Point[]
                     {
-                        new Point(0.50f, 0f),
-                        new Point(0.22f, 0.9f),
-                        new Point(0.96f, 0.38f),
-                        new Point(0.04f, 0.38f),
-                        new Point(0.78f, 0.9f),
-                        new Point(0.50f, 0f),
-                    }.Select(point => point.Multiply(render.IconSize).Subtract(render.IconSize / 2).Rotate(_rotateRadians).Multiply(scaleWidth, _scaleHeight)).ToArray();
+                        new Point(0.50f, 1f),
+                        new Point(0.22f, 0.1f),
+                        new Point(0.96f, 0.62f),
+                        new Point(0.04f, 0.62f),
+                        new Point(0.78f, 0.1f),
+                        new Point(0.50f, 1f),
+                    }.Select(point => point.Multiply(render.IconSize).Subtract(render.IconSize / 2).Multiply(scaleWidth, _scaleHeight)).ToArray();
             }
 
             return new Point[]

--- a/Settings/Rendering.cs
+++ b/Settings/Rendering.cs
@@ -116,7 +116,8 @@ namespace MapAssist.Settings
         Dress,
         Kite,
         Stick,
-        Leg
+        Leg,
+        Pentagram
     }
 
     public enum TextAlign


### PR DESCRIPTION
Overlay mode showing small/medium/large icon:
![pent1](https://user-images.githubusercontent.com/10291543/171042192-849c0638-33d5-499f-8dc5-a5605f2b2928.png)
![pent2](https://user-images.githubusercontent.com/10291543/171042193-66cf0f5c-d0ab-427e-a1d6-793602f58dfa.png)
![pent3](https://user-images.githubusercontent.com/10291543/171042195-31503fa8-4beb-4128-bcbb-0868e7bafe97.png)

Non-overlay mode example:
![pent4](https://user-images.githubusercontent.com/10291543/171042197-e9d919b6-0588-4965-8e99-b5c443b3b21d.png)

How it looks when Outline + Fill is used:
![pent5](https://user-images.githubusercontent.com/10291543/171042198-b908c4e6-77d9-4f6e-aa93-48bba7cbc003.png)

How it looks when only Fill is used (looks strange but sharing anyways for visibility)
![pent6](https://user-images.githubusercontent.com/10291543/171042200-9e9972cf-fc96-4de4-a424-68192b3cdeb8.png)
