### PR TITLE
Small changes for Line Toggles and Hostile Player icon

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -36,7 +36,6 @@ RenderingConfiguration:
   ShowExpProgress: true
   ShowPotionBelt: true
   ShowResistances: false
-  LinesMode: All
 MapConfiguration:
   SuperUniqueMonster:
     IconOutlineColor: Yellow

--- a/Forms/ConfigEditor.Designer.cs
+++ b/Forms/ConfigEditor.Designer.cs
@@ -88,9 +88,12 @@
             this.chkMana = new System.Windows.Forms.CheckBox();
             this.chkLifePerc = new System.Windows.Forms.CheckBox();
             this.chkLife = new System.Windows.Forms.CheckBox();
-            this.grpPresets = new System.Windows.Forms.GroupBox();
-            this.lblMapLinesMode = new System.Windows.Forms.Label();
-            this.cboMapLinesMode = new System.Windows.Forms.ComboBox();
+            this.grpLines = new System.Windows.Forms.GroupBox();
+            this.chkLinesWaypoint = new System.Windows.Forms.CheckBox();
+            this.chkLinesQuest = new System.Windows.Forms.CheckBox();
+            this.chkLinesNextArea = new System.Windows.Forms.CheckBox();
+            this.chkLinesCorpse = new System.Windows.Forms.CheckBox();
+            this.chkLinesHostiles = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.chkDebuffs = new System.Windows.Forms.CheckBox();
             this.chkPassives = new System.Windows.Forms.CheckBox();
@@ -199,11 +202,13 @@
             this.groupBox8 = new System.Windows.Forms.GroupBox();
             this.label3 = new System.Windows.Forms.Label();
             this.chkDPIAware = new System.Windows.Forms.CheckBox();
+            this.chkLinesMagicFindArea = new System.Windows.Forms.CheckBox();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
             this.groupBox9 = new System.Windows.Forms.GroupBox();
             this.label6 = new System.Windows.Forms.Label();
             this.linkWebsite = new System.Windows.Forms.LinkLabel();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.chkLinesShrines = new System.Windows.Forms.CheckBox();
             this.tabControl1.SuspendLayout();
             this.tabPage5.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -217,7 +222,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.opacity)).BeginInit();
             this.tabPage3.SuspendLayout();
             this.groupBox7.SuspendLayout();
-            this.grpPresets.SuspendLayout();
+            this.grpLines.SuspendLayout();
             this.groupBox3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.buffSize)).BeginInit();
             this.tabPage2.SuspendLayout();
@@ -875,7 +880,7 @@
             // tabPage3
             // 
             this.tabPage3.Controls.Add(this.groupBox7);
-            this.tabPage3.Controls.Add(this.grpPresets);
+            this.tabPage3.Controls.Add(this.grpLines);
             this.tabPage3.Controls.Add(this.groupBox3);
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
@@ -897,7 +902,7 @@
             this.groupBox7.Controls.Add(this.chkMana);
             this.groupBox7.Controls.Add(this.chkLifePerc);
             this.groupBox7.Controls.Add(this.chkLife);
-            this.groupBox7.Location = new System.Drawing.Point(11, 153);
+            this.groupBox7.Location = new System.Drawing.Point(11, 140);
             this.groupBox7.Name = "groupBox7";
             this.groupBox7.Size = new System.Drawing.Size(388, 90);
             this.groupBox7.TabIndex = 25;
@@ -918,7 +923,7 @@
             // chkResistances
             // 
             this.chkResistances.AutoSize = true;
-            this.chkResistances.Location = new System.Drawing.Point(102, 65);
+            this.chkResistances.Location = new System.Drawing.Point(116, 65);
             this.chkResistances.Name = "chkResistances";
             this.chkResistances.Size = new System.Drawing.Size(84, 17);
             this.chkResistances.TabIndex = 24;
@@ -929,7 +934,7 @@
             // chkExpProgress
             // 
             this.chkExpProgress.AutoSize = true;
-            this.chkExpProgress.Location = new System.Drawing.Point(240, 42);
+            this.chkExpProgress.Location = new System.Drawing.Point(233, 42);
             this.chkExpProgress.Name = "chkExpProgress";
             this.chkExpProgress.Size = new System.Drawing.Size(88, 17);
             this.chkExpProgress.TabIndex = 5;
@@ -940,7 +945,7 @@
             // chkCurrentLevel
             // 
             this.chkCurrentLevel.AutoSize = true;
-            this.chkCurrentLevel.Location = new System.Drawing.Point(240, 19);
+            this.chkCurrentLevel.Location = new System.Drawing.Point(233, 19);
             this.chkCurrentLevel.Name = "chkCurrentLevel";
             this.chkCurrentLevel.Size = new System.Drawing.Size(89, 17);
             this.chkCurrentLevel.TabIndex = 4;
@@ -951,7 +956,7 @@
             // chkManaPerc
             // 
             this.chkManaPerc.AutoSize = true;
-            this.chkManaPerc.Location = new System.Drawing.Point(102, 42);
+            this.chkManaPerc.Location = new System.Drawing.Point(116, 42);
             this.chkManaPerc.Name = "chkManaPerc";
             this.chkManaPerc.Size = new System.Drawing.Size(93, 17);
             this.chkManaPerc.TabIndex = 3;
@@ -973,7 +978,7 @@
             // chkLifePerc
             // 
             this.chkLifePerc.AutoSize = true;
-            this.chkLifePerc.Location = new System.Drawing.Point(102, 19);
+            this.chkLifePerc.Location = new System.Drawing.Point(116, 19);
             this.chkLifePerc.Name = "chkLifePerc";
             this.chkLifePerc.Size = new System.Drawing.Size(83, 17);
             this.chkLifePerc.TabIndex = 1;
@@ -992,40 +997,78 @@
             this.chkLife.UseVisualStyleBackColor = true;
             this.chkLife.CheckedChanged += new System.EventHandler(this.chkLife_CheckedChanged);
             // 
-            // grpPresets
+            // grpLines
             // 
-            this.grpPresets.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.grpLines.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.grpPresets.Controls.Add(this.lblMapLinesMode);
-            this.grpPresets.Controls.Add(this.cboMapLinesMode);
-            this.grpPresets.Location = new System.Drawing.Point(11, 263);
-            this.grpPresets.Name = "grpPresets";
-            this.grpPresets.Size = new System.Drawing.Size(388, 51);
-            this.grpPresets.TabIndex = 24;
-            this.grpPresets.TabStop = false;
-            this.grpPresets.Text = "Presets";
+            this.grpLines.Controls.Add(this.chkLinesShrines);
+            this.grpLines.Controls.Add(this.chkLinesWaypoint);
+            this.grpLines.Controls.Add(this.chkLinesQuest);
+            this.grpLines.Controls.Add(this.chkLinesNextArea);
+            this.grpLines.Controls.Add(this.chkLinesCorpse);
+            this.grpLines.Controls.Add(this.chkLinesHostiles);
+            this.grpLines.Location = new System.Drawing.Point(11, 236);
+            this.grpLines.Name = "grpLines";
+            this.grpLines.Size = new System.Drawing.Size(388, 71);
+            this.grpLines.TabIndex = 24;
+            this.grpLines.TabStop = false;
+            this.grpLines.Text = "Toggle Map Lines";
             // 
-            // lblMapLinesMode
+            // chkLinesWaypoint
             // 
-            this.lblMapLinesMode.AutoSize = true;
-            this.lblMapLinesMode.Location = new System.Drawing.Point(6, 24);
-            this.lblMapLinesMode.Name = "lblMapLinesMode";
-            this.lblMapLinesMode.Size = new System.Drawing.Size(86, 13);
-            this.lblMapLinesMode.TabIndex = 21;
-            this.lblMapLinesMode.Text = "Map Lines Mode";
-            this.lblMapLinesMode.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.chkLinesWaypoint.AutoSize = true;
+            this.chkLinesWaypoint.Location = new System.Drawing.Point(233, 46);
+            this.chkLinesWaypoint.Name = "chkLinesWaypoint";
+            this.chkLinesWaypoint.Size = new System.Drawing.Size(76, 17);
+            this.chkLinesWaypoint.TabIndex = 6;
+            this.chkLinesWaypoint.Text = "Waypoints";
+            this.chkLinesWaypoint.UseVisualStyleBackColor = true;
+            this.chkLinesWaypoint.CheckedChanged += new System.EventHandler(this.chkLinesWaypoint_CheckedChanged);
             // 
-            // cboMapLinesMode
+            // chkLinesQuest
             // 
-            this.cboMapLinesMode.AllowDrop = true;
-            this.cboMapLinesMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboMapLinesMode.FormattingEnabled = true;
-            this.cboMapLinesMode.Location = new System.Drawing.Point(117, 21);
-            this.cboMapLinesMode.Name = "cboMapLinesMode";
-            this.cboMapLinesMode.Size = new System.Drawing.Size(124, 21);
-            this.cboMapLinesMode.TabIndex = 20;
-            this.cboMapLinesMode.SelectedIndexChanged += new System.EventHandler(this.cboMapLinesMode_SelectedIndexChanged);
+            this.chkLinesQuest.AutoSize = true;
+            this.chkLinesQuest.Location = new System.Drawing.Point(116, 46);
+            this.chkLinesQuest.Name = "chkLinesQuest";
+            this.chkLinesQuest.Size = new System.Drawing.Size(54, 17);
+            this.chkLinesQuest.TabIndex = 4;
+            this.chkLinesQuest.Text = "Quest";
+            this.chkLinesQuest.UseVisualStyleBackColor = true;
+            this.chkLinesQuest.CheckedChanged += new System.EventHandler(this.chkLinesQuest_CheckedChanged);
+            // 
+            // chkLinesNextArea
+            // 
+            this.chkLinesNextArea.AutoSize = true;
+            this.chkLinesNextArea.Location = new System.Drawing.Point(116, 23);
+            this.chkLinesNextArea.Name = "chkLinesNextArea";
+            this.chkLinesNextArea.Size = new System.Drawing.Size(73, 17);
+            this.chkLinesNextArea.TabIndex = 3;
+            this.chkLinesNextArea.Text = "Next Area";
+            this.chkLinesNextArea.UseVisualStyleBackColor = true;
+            this.chkLinesNextArea.CheckedChanged += new System.EventHandler(this.chkLinesNextArea_CheckedChanged);
+            // 
+            // chkLinesCorpse
+            // 
+            this.chkLinesCorpse.AutoSize = true;
+            this.chkLinesCorpse.Location = new System.Drawing.Point(9, 46);
+            this.chkLinesCorpse.Name = "chkLinesCorpse";
+            this.chkLinesCorpse.Size = new System.Drawing.Size(59, 17);
+            this.chkLinesCorpse.TabIndex = 2;
+            this.chkLinesCorpse.Text = "Corpse";
+            this.chkLinesCorpse.UseVisualStyleBackColor = true;
+            this.chkLinesCorpse.CheckedChanged += new System.EventHandler(this.chkLinesCorpse_CheckedChanged);
+            // 
+            // chkLinesHostiles
+            // 
+            this.chkLinesHostiles.AutoSize = true;
+            this.chkLinesHostiles.Location = new System.Drawing.Point(9, 23);
+            this.chkLinesHostiles.Name = "chkLinesHostiles";
+            this.chkLinesHostiles.Size = new System.Drawing.Size(95, 17);
+            this.chkLinesHostiles.TabIndex = 1;
+            this.chkLinesHostiles.Text = "Hostile Players";
+            this.chkLinesHostiles.UseVisualStyleBackColor = true;
+            this.chkLinesHostiles.CheckedChanged += new System.EventHandler(this.chkLinesHostiles_CheckedChanged);
             // 
             // groupBox3
             // 
@@ -2337,6 +2380,16 @@
             this.chkDPIAware.UseVisualStyleBackColor = true;
             this.chkDPIAware.CheckedChanged += new System.EventHandler(this.chkDPIAware_CheckedChanged);
             // 
+            // chkLinesMagicFindArea
+            // 
+            this.chkLinesMagicFindArea.AutoSize = true;
+            this.chkLinesMagicFindArea.Location = new System.Drawing.Point(116, 23);
+            this.chkLinesMagicFindArea.Name = "chkLinesMagicFindArea";
+            this.chkLinesMagicFindArea.Size = new System.Drawing.Size(103, 17);
+            this.chkLinesMagicFindArea.TabIndex = 5;
+            this.chkLinesMagicFindArea.Text = "Magic Find Area";
+            this.chkLinesMagicFindArea.UseVisualStyleBackColor = true;
+            // 
             // groupBox9
             // 
             this.groupBox9.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -2381,6 +2434,17 @@
             this.pictureBox1.TabIndex = 6;
             this.pictureBox1.TabStop = false;
             // 
+            // chkLinesShrines
+            // 
+            this.chkLinesShrines.AutoSize = true;
+            this.chkLinesShrines.Location = new System.Drawing.Point(233, 23);
+            this.chkLinesShrines.Name = "chkLinesShrines";
+            this.chkLinesShrines.Size = new System.Drawing.Size(61, 17);
+            this.chkLinesShrines.TabIndex = 7;
+            this.chkLinesShrines.Text = "Shrines";
+            this.chkLinesShrines.UseVisualStyleBackColor = true;
+            this.chkLinesShrines.CheckedChanged += new System.EventHandler(this.chkLinesShrines_CheckedChanged);
+            // 
             // ConfigEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -2416,8 +2480,8 @@
             this.tabPage3.ResumeLayout(false);
             this.groupBox7.ResumeLayout(false);
             this.groupBox7.PerformLayout();
-            this.grpPresets.ResumeLayout(false);
-            this.grpPresets.PerformLayout();
+            this.grpLines.ResumeLayout(false);
+            this.grpLines.PerformLayout();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.buffSize)).EndInit();
@@ -2564,9 +2628,7 @@
         private System.Windows.Forms.CheckBox chkToggleViaMap;
         private System.Windows.Forms.Label lblIconOpacity;
         private System.Windows.Forms.CheckBox chkToggleViaPanels;
-        private System.Windows.Forms.GroupBox grpPresets;
-        private System.Windows.Forms.Label lblMapLinesMode;
-        private System.Windows.Forms.ComboBox cboMapLinesMode;
+        private System.Windows.Forms.GroupBox grpLines;
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.Label lblBuffSizeValue;
         private System.Windows.Forms.Label label5;
@@ -2631,5 +2693,12 @@
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.LinkLabel linkWebsite;
         private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.CheckBox chkLinesWaypoint;
+        private System.Windows.Forms.CheckBox chkLinesMagicFindArea;
+        private System.Windows.Forms.CheckBox chkLinesQuest;
+        private System.Windows.Forms.CheckBox chkLinesNextArea;
+        private System.Windows.Forms.CheckBox chkLinesCorpse;
+        private System.Windows.Forms.CheckBox chkLinesHostiles;
+        private System.Windows.Forms.CheckBox chkLinesShrines;
     }
 }

--- a/Forms/ConfigEditor.cs
+++ b/Forms/ConfigEditor.cs
@@ -33,6 +33,11 @@ namespace MapAssist
                 cboRenderOption.Items.Add(property.Name.ToProperCase());
             }
 
+            if (cboRenderOption.Items.Count > 0)
+            {
+                cboRenderOption.SelectedIndex = 0;
+            }
+
             foreach (var element in Enum.GetNames(typeof(BuffPosition)))
             {
                 cboBuffPosition.Items.Add(element.ToProperCase());
@@ -51,11 +56,6 @@ namespace MapAssist
             foreach (Locale element in Enum.GetValues(typeof(Locale)))
             {
                 cboLanguage.Items.Add(LocaleExtensions.Name(element));
-            }
-
-            foreach (var element in Enum.GetNames(typeof(MapLinesMode)))
-            {
-                cboMapLinesMode.Items.Add(element);
             }
 
             foreach (var element in Enum.GetNames(typeof(GameInfoPosition)))
@@ -93,7 +93,13 @@ namespace MapAssist
             chkDebuffs.Checked = MapAssistConfiguration.Loaded.RenderingConfiguration.ShowBuffBarDebuffs;
             chkAlertLowerRes.Checked = MapAssistConfiguration.Loaded.RenderingConfiguration.BuffAlertLowRes;
             cboBuffPosition.SelectedIndex = cboBuffPosition.FindStringExact(MapAssistConfiguration.Loaded.RenderingConfiguration.BuffPosition.ToString().ToProperCase());
-            cboMapLinesMode.SelectedIndex = cboMapLinesMode.FindStringExact(MapAssistConfiguration.Loaded.RenderingConfiguration.LinesMode.ToString().ToProperCase());
+
+            chkLinesHostiles.Checked = MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.CanDrawLine();
+            chkLinesCorpse.Checked = MapAssistConfiguration.Loaded.MapConfiguration.Corpse.CanDrawLine();
+            chkLinesNextArea.Checked = MapAssistConfiguration.Loaded.MapConfiguration.NextArea.CanDrawLine();
+            chkLinesQuest.Checked = MapAssistConfiguration.Loaded.MapConfiguration.Quest.CanDrawLine();
+            chkLinesWaypoint.Checked = MapAssistConfiguration.Loaded.MapConfiguration.Waypoint.CanDrawLine();
+            chkLinesShrines.Checked = MapAssistConfiguration.Loaded.MapConfiguration.Shrine.CanDrawLine();
 
             chkLife.Checked = MapAssistConfiguration.Loaded.RenderingConfiguration.ShowLife;
             chkMana.Checked = MapAssistConfiguration.Loaded.RenderingConfiguration.ShowMana;
@@ -450,11 +456,6 @@ namespace MapAssist
         private void cboBuffPosition_SelectedIndexChanged(object sender, EventArgs e)
         {
             MapAssistConfiguration.Loaded.RenderingConfiguration.BuffPosition = (BuffPosition)cboBuffPosition.SelectedIndex;
-        }
-
-        private void cboMapLinesMode_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            MapAssistConfiguration.Loaded.RenderingConfiguration.LinesMode = (MapLinesMode)cboMapLinesMode.SelectedIndex;
         }
 
         private void chkShowGameName_CheckedChanged(object sender, EventArgs e)
@@ -1225,6 +1226,45 @@ namespace MapAssist
         private void linkWebsite_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             System.Diagnostics.Process.Start(linkWebsite.Text);
+        }
+
+        private void HandleLineToggle(CheckBox input, PointOfInterestRendering rendering)
+        {
+            if (input.Checked == rendering.CanDrawLine())
+            {
+                return;
+            }
+            rendering.ToggleLine();
+        }
+
+        private void chkLinesHostiles_CheckedChanged(object sender, EventArgs e)
+        {
+            HandleLineToggle(chkLinesHostiles, MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer);
+        }
+
+        private void chkLinesCorpse_CheckedChanged(object sender, EventArgs e)
+        {
+            HandleLineToggle(chkLinesCorpse, MapAssistConfiguration.Loaded.MapConfiguration.Corpse);
+        }
+
+        private void chkLinesNextArea_CheckedChanged(object sender, EventArgs e)
+        {
+            HandleLineToggle(chkLinesNextArea, MapAssistConfiguration.Loaded.MapConfiguration.NextArea);
+        }
+
+        private void chkLinesQuest_CheckedChanged(object sender, EventArgs e)
+        {
+            HandleLineToggle(chkLinesQuest, MapAssistConfiguration.Loaded.MapConfiguration.Quest);
+        }
+
+        private void chkLinesWaypoint_CheckedChanged(object sender, EventArgs e)
+        {
+            HandleLineToggle(chkLinesWaypoint, MapAssistConfiguration.Loaded.MapConfiguration.Waypoint);
+        }
+
+        private void chkLinesShrines_CheckedChanged(object sender, EventArgs e)
+        {
+            HandleLineToggle(chkLinesShrines, MapAssistConfiguration.Loaded.MapConfiguration.Shrine);
         }
     }
 }

--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -272,7 +272,7 @@ namespace MapAssist.Helpers
                         continue;
                     }
 
-                    if (CanDrawMapLines(MapLinesMode.PVE) && poi.RenderingSettings.CanDrawLine() && !area.Area.IsTown() && poi.Area == _areaData.Area)
+                    if (poi.RenderingSettings.CanDrawLine() && !_areaData.Area.IsTown() && !area.Area.IsTown() && poi.Area == _areaData.Area)
                     {
                         var fontSize = gfx.ScaleFontSize((float)poi.RenderingSettings.LabelFontSize);
                         var padding = poi.RenderingSettings.CanDrawLabel() ? fontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
@@ -640,7 +640,7 @@ namespace MapAssist.Helpers
                             // not in my party
                             var rendering = (myPlayer
                                 ? MapAssistConfiguration.Loaded.MapConfiguration.Player
-                                : (playerUnit.IsHostile
+                                : (!playerUnit.IsCorpse && (playerUnit.IsHostile || _gameData.PlayerUnit.IsHostileTo(player))
                                     ? MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer
                                     : MapAssistConfiguration.Loaded.MapConfiguration.NonPartyPlayer));
 
@@ -649,7 +649,7 @@ namespace MapAssist.Helpers
                                 drawPlayerIcons.Add((rendering, playerUnit.Position));
                             }
 
-                            if (CanDrawMapLines(MapLinesMode.PVP) && rendering.CanDrawLine() && playerUnit.IsHostile && !playerUnit.Area.IsTown())
+                            if (rendering.CanDrawLine() && !_areaData.Area.IsTown() && !playerUnit.Area.IsTown())
                             {
                                 var fontSize = gfx.ScaleFontSize((float)MapAssistConfiguration.Loaded.MapConfiguration.HostilePlayer.LabelFontSize);
                                 var padding = rendering.CanDrawLabel() ? fontSize * 1.3f / 2 : 0; // 1.3f is the line height adjustment
@@ -1435,14 +1435,6 @@ namespace MapAssist.Helpers
         }
 
         // Utility Functions
-        private bool CanDrawMapLines(MapLinesMode mode)
-        {
-            if (_areaData.Area.IsTown()) return false;
-
-            var configMode = MapAssistConfiguration.Loaded.RenderingConfiguration.LinesMode;
-            return configMode == MapLinesMode.All || configMode == mode;
-        }
-
         private Point[] GetIconShape(IconRendering render,
             bool equalScaling = false)
         {

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -276,9 +276,6 @@ public class RenderingConfiguration
 
     [YamlMember(Alias = "ShowResistances", ApplyNamingConventions = false)]
     public bool ShowResistances { get; set; }
-
-    [YamlMember(Alias = "LinesMode", ApplyNamingConventions = false)]
-    public MapLinesMode LinesMode { get; set; }
 }
 
 public class HotkeyConfiguration

--- a/Settings/Rendering.cs
+++ b/Settings/Rendering.cs
@@ -58,7 +58,7 @@ namespace MapAssist.Settings
 
         public bool CanDrawLine()
         {
-            return LineColor != Color.Transparent && LineColor != Color.Empty && LineThickness > 0;
+            return LineColor.A > 0 && LineThickness > 0;
         }
 
         public bool CanDrawArrowHead()
@@ -68,7 +68,32 @@ namespace MapAssist.Settings
 
         public bool CanDrawLabel()
         {
-            return LabelColor != Color.Transparent && LabelColor != Color.Empty && !string.IsNullOrWhiteSpace(LabelFont) && LabelFontSize > 0;
+            return LabelColor.A > 0 && !string.IsNullOrWhiteSpace(LabelFont) && LabelFontSize > 0;
+        }
+
+        public void ToggleLine()
+        {
+            if (LineThickness != 0)
+            {
+                LineThickness = 0;
+                return;
+            }
+
+            LineThickness = 2;
+
+            if (ArrowHeadSize == 0)
+            {
+                ArrowHeadSize = 15;
+            }
+
+            if (LineColor.A == 0)
+            {
+                LineColor = IconColor.A > 0
+                    ? IconColor
+                    : IconOutlineColor.A > 0
+                        ? IconOutlineColor
+                        : Color.Red;
+            }
         }
     }
 

--- a/Types/UnitPlayer.cs
+++ b/Types/UnitPlayer.cs
@@ -97,7 +97,7 @@ namespace MapAssist.Types
 
         private ushort PartyID => RosterEntry != null ? RosterEntry.PartyID : ushort.MaxValue;
 
-        private bool IsHostileTo(RosterEntry otherUnit)
+        public bool IsHostileTo(RosterEntry otherUnit)
         {
             if (UnitId == otherUnit.UnitId)
             {


### PR DESCRIPTION
Replaced `LinesMode` with checkboxes for choosing certain lines to toggle on/off.  This way there's no extra yaml config and the checkboxes are basically a shortcut for managing lines settings in the Drawing tab for a select few POI.

![lines](https://user-images.githubusercontent.com/10291543/171626314-414c8ec1-ba06-447b-bbe4-9dffcdaf1c23.png)

I made it so players you hostile will continue to show as HostilePlayer icon if they unhostile you.  Previously the icon would change to NonPartyPlayer if they unhostile you.

One other small change I made is to auto-select the first combobox item in the Drawing tab on window load, so that tab starts with more content showing