### PR TITLE
Add CheckVendor option to item filters

### DIFF
--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -32,6 +32,8 @@ namespace MapAssist.Helpers
                 // Skip generic unid rules for identified items on ground or in inventory
                 if (item.IsIdentified && (item.IsDropped || item.IsAnyPlayerHolding) && rule.TargetsUnidItem()) continue;
 
+                if (item.IsInStore && !rule.CheckVendor) continue;
+
                 // Requirement check functions
                 var requirementsFunctions = new Dictionary<string, Func<bool>>()
                 {

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -70,6 +70,7 @@ namespace MapAssist.Settings
 
         public ItemTier[] Tiers { get; set; }
         public bool PlaySoundOnDrop { get; set; } = true;
+        public bool CheckVendor { get; set; } = true;
         public string SoundFile { get; set; }
         public ItemQuality[] Qualities { get; set; }
         public int[] Sockets { get; set; }


### PR DESCRIPTION
With `CheckVendor` it is possible to add a item filter rule for just dropped or identified items. That is interesting for example for rules like "I want to see every elite armor which drops because I want to sell it".

A possible description for wiki (do not know if I can change it too):

# How do I ignore a rule for an item seen at the merchant rule?

Add `CheckVendor: false` to the rule, as such:

```yml
# This will show dropped elite armors but not elite armores at the vendor
Armors:
  - Tiers: [elite]
    CheckVendor: false
```