### PR TITLE
Add Rendering option to item filter

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -504,17 +504,17 @@ namespace MapAssist.Helpers
 
             if (MapAssistConfiguration.Loaded.ItemLog.Enabled)
             {
-                foreach (var item in _gameData.Items)
+                foreach (var item in _gameData.FilteredItems)
                 {
-                    if (item.IsValidItem && item.IsDropped && !item.IsIdentified)
+                    if (item.UnitItem.IsValidItem && item.UnitItem.IsDropped && !item.UnitItem.IsIdentified)
                     {
-                        if (!_areaData.IncludesPoint(item.Position) && !IsInBounds(item.Position, _gameData.PlayerPosition)) continue; // Don't show item if not in drawn areas
+                        if (!_areaData.IncludesPoint(item.UnitItem.Position) && !IsInBounds(item.UnitItem.Position, _gameData.PlayerPosition)) continue; // Don't show item if not in drawn areas
 
-                        var itemPosition = item.Position;
-                        var render = MapAssistConfiguration.Loaded.MapConfiguration.Item;
+                        var itemPosition = item.UnitItem.Position;
+                        var render = item.Rendering ?? MapAssistConfiguration.Loaded.MapConfiguration.Item;
 
                         drawItemIcons.Add((render, itemPosition));
-                        drawItemLabels.Add((render, item.Position, item.ItemBaseName, item.ItemBaseColor));
+                        drawItemLabels.Add((render, item.UnitItem.Position, item.UnitItem.ItemBaseName, item.UnitItem.ItemBaseColor));
                     }
                 }
             }

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -308,7 +308,7 @@ namespace MapAssist.Helpers
                     rawItemUnits.Add(item);
                 }
 
-                var itemList = Items.ItemLog[_currentProcessId].Select(item =>
+                var filteredItemList = Items.ItemLog[_currentProcessId].Select(item =>
                 {
                     if (cache.TryGetValue(item.ItemHashString, out var cachedItem) && ((UnitItem)cachedItem).HashString == item.ItemHashString)
                     {
@@ -320,7 +320,10 @@ namespace MapAssist.Helpers
                         item.UnitItem.MarkInvalid();
                     }
 
-                    return item.UnitItem;
+                    return new FilteredItem {
+                        Rendering = item.Rule?.Rendering,
+                        UnitItem = item.UnitItem
+                    };
                 }).Where(x => x != null).ToArray();
 
                 // Player wearing items
@@ -377,7 +380,7 @@ namespace MapAssist.Helpers
                     Summons = summonsList,
                     Objects = objectList,
                     Missiles = missileList,
-                    Items = itemList,
+                    FilteredItems = filteredItemList,
                     AllItems = allItems,
                     ItemLog = Items.ItemLog[_currentProcessId].ToArray(),
                     Session = _sessions[_currentProcessId],

--- a/MapAssist.csproj
+++ b/MapAssist.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Types\PointOfInterest.cs" />
     <Compile Include="Types\RawAreaData.cs" />
     <Compile Include="Settings\Rendering.cs" />
+    <Compile Include="Types\FilteredItem.cs" />
     <Compile Include="Types\UnitAny.cs" />
     <Compile Include="Types\UnitMissile.cs" />
     <Compile Include="Types\UnitObject.cs" />

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -72,6 +72,7 @@ namespace MapAssist.Settings
         public bool PlaySoundOnDrop { get; set; } = true;
         public bool CheckVendor { get; set; } = true;
         public string SoundFile { get; set; }
+        public PointOfInterestRendering Rendering { get; set; } = null;
         public ItemQuality[] Qualities { get; set; }
         public int[] Sockets { get; set; }
         public bool? Ethereal { get; set; }

--- a/Types/FilteredItem.cs
+++ b/Types/FilteredItem.cs
@@ -1,0 +1,10 @@
+﻿using MapAssist.Settings;
+
+namespace MapAssist.Types
+{
+    public class FilteredItem
+    {
+        public UnitItem UnitItem { get; set; }
+        public PointOfInterestRendering Rendering { get; set; }
+    }
+}

--- a/Types/GameData.cs
+++ b/Types/GameData.cs
@@ -22,7 +22,7 @@ namespace MapAssist.Types
         public UnitMonster[] Summons;
         public UnitObject[] Objects;
         public UnitMissile[] Missiles;
-        public UnitItem[] Items;
+        public FilteredItem[] FilteredItems;
         public UnitItem[] AllItems;
         public ItemLogEntry[] ItemLog;
         public Session Session;


### PR DESCRIPTION
With `Rendering` it is possible to display found items with a certain rule in a different styling than the main items.

This can be used to get a better overview of different types of filtered items. Like the default orange for really important items and gray for items that can sell for big bucks.

Example:

```yml
# Config.yml
RenderingConfiguration:
  Item:
    IconColor: DarkOrange
    IconShape: Ellipse
    IconSize: 8
    LabelFontSize: 10
    LabelFont: Exocet Blizzard Mixed Caps
    LabelTextShadow: true

# ItemFilter.yaml
Studded Leather:
  - Qualities: [set]

Armors:
  - Sockets: [4]
    Rendering:
      IconColor: 225, 30, 30
      IconShape: Ellipse
      IconSize: 8
      LabelFontSize: 10
      LabelFont: Exocet Blizzard Mixed Caps
      LabelTextShadow: true
  - Tiers: [elite]
    Rendering:
      IconColor: Gray
      IconShape: Ellipse
      IconSize: 5
      LabelFontSize: 10
      LabelFont: Exocet Blizzard Mixed Caps
      LabelTextShadow: true
```

Result:
![grafik](https://user-images.githubusercontent.com/106914358/172232863-af8c6b50-a898-40fc-9903-d1faf24b3ea0.png)

Could be interesting to provide a merging mechanism, so that not all values must be overwritten but I kept it as simple as possible for the beginning. I'm be aware that this feature will not use so many users so I think it is ok for now.

It might be interesting to provide a merge mechanism so that all values don't have to be defined, but I've kept it as simple as possible.
I'm aware that this feature won't be used by very many users, so I think it's ok for now.

A possible description for wiki:

# How do I display items maches a certain rule with an own styling?

Add `Rendering` to the rule, as such:

```yml
# All items are shown with the global Item configs, only Full Rejuvenation Potion are shown in purple
Full Rejuvenation Potion:
  -  Rendering:
      IconColor: Purple
      IconShape: Ellipse
      IconSize: 8
      LabelFontSize: 10
      LabelFont: Microsoft Sans Serif
      LabelTextShadow: true
```

Hint: The entry `RenderingConfiguration->Item` in `Config.yaml` is the base item styling and can be used as example.