### PR TITLE
Add ShowInLog option to item filters

### DIFF
--- a/Helpers/Compositor.cs
+++ b/Helpers/Compositor.cs
@@ -1053,7 +1053,7 @@ namespace MapAssist.Helpers
             var shadowOffset = fontSize * 0.0625f; // 1/16th
 
             // Item Log
-            var itemsToShow = _gameData.ItemLog.Where(item => item != null && !item.ItemLogExpired && item.UnitItem.ItemBaseColor != Color.Empty).ToArray();
+            var itemsToShow = _gameData.ItemLog.Where(item => item != null && !item.ItemLogExpired && item.UnitItem.ItemBaseColor != Color.Empty && (item.Rule?.ShowInLog ?? true)).ToArray();
             for (var i = 0; i < itemsToShow.Length; i++)
             {
                 var item = itemsToShow[i];

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -71,6 +71,7 @@ namespace MapAssist.Settings
         public ItemTier[] Tiers { get; set; }
         public bool PlaySoundOnDrop { get; set; } = true;
         public bool CheckVendor { get; set; } = true;
+        public bool ShowInLog { get; set; } = true;
         public string SoundFile { get; set; }
         public ItemQuality[] Qualities { get; set; }
         public int[] Sockets { get; set; }


### PR DESCRIPTION
With `ShowInLog` it is possible to show a filtered item just in the map.

That can be used to keep only the important items in logs, and items like "good to sell" or "Full Rejuvenation Potion" can be only shown in map.

This is particularly interesting in combination with my second PR, when the "not so interesting items" are also visualized differently on the map.

A possible description for wiki:

# How do I not show filtered items in the log?

Add `ShowInLog: false` to the rule, as such:

```yml
# This will only show dropped Rejuvenation Potion on the map but not in the log
Full Rejuvenation Potion:
  - ShowInLog: false
```