### PR TITLE
Fixed k2 and k3 in map seed decryption

### DIFF
--- a/Types/MapSeed.cs
+++ b/Types/MapSeed.cs
@@ -22,13 +22,14 @@ namespace MapAssist.Types
             {
                 try
                 {
-                    //var k2 = processContext.Read<ulong>(IntPtr.Add(processContext.BaseAddr, (int)(0x20DEA40 + (a5 >> 52))));
-                    //var k3 = processContext.Read<ulong>(IntPtr.Add(processContext.BaseAddr, (int)(0x20DEA40 + (a5 & 0xFFF))));
                     var ldr = GetLdrAddress();
                     var dwInitSeedHash = _seedHash;
+                    var k0 = 0xB133105CF0F31CD6 ^ 0x770AFD680A3D2D6D;
                     var k1 = 0x176E2BC088CB2DA9ul ^ (ulong)ldr.ToInt64() ^ 0xA23D40A5FD70B4A4;
-                    var k2 = 0x0D6CD757E08A4F816;
-                    var k3 = 0x0DF49DC967C7D96E0;
+                    var t1 = IntPtr.Add(processContext.BaseAddr, (int)(0x20DEA40 + (k0 & 0xFFF)));
+                    var t2 = IntPtr.Add(processContext.BaseAddr, (int)(0x20DEA40 + (k0 >> 52)));
+                    var k2 = processContext.Read<ulong>(t1);
+                    var k3 = processContext.Read<ulong>(t2);
                     var seed = k1 ^ dwInitSeedHash | (k1 ^ dwInitSeedHash | (k1 ^ (dwInitSeedHash | (dwInitSeedHash | dwInitSeedHash & 0xFFFFFFFF00000000 ^ ((dwInitSeedHash ^ ~HiDWord(k2)) << 32)) & 0xFFFFFFFF00000000 ^ ((dwInitSeedHash ^ 0x7734D256) << 32))) & 0xFFFFFFFF00000000 ^ ((ror4(HiDWord(k3), 11) ^ ~(k1 ^ dwInitSeedHash)) << 32)) & 0xFFFFFFFF00000000 ^ ((k1 ^ dwInitSeedHash ^ ~k2) << 32);
 
                     Seed = (uint)(int)seed;


### PR DESCRIPTION
Replaced the hard coded k2 and k3, need pattern for the encryption key table.