### PR TITLE
Allow loot filter to check unid items in different game session

### DIFF
--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -270,7 +270,7 @@ namespace MapAssist.Helpers
 
                     if (Items.ItemUnitIdsToSkip[_currentProcessId].Contains(item.UnitId)) continue;
 
-                    if (_playerMapChanged[_currentProcessId] && item.IsAnyPlayerHolding && item.Item != Item.HoradricCube && !Items.ItemUnitIdsToSkip[_currentProcessId].Contains(item.UnitId))
+                    if (_playerMapChanged[_currentProcessId] && item.IsAnyPlayerHolding && (item.IsIdentified || item.ItemData.ItemQuality <= ItemQuality.SUPERIOR) && !Items.ItemUnitIdsToSkip[_currentProcessId].Contains(item.UnitId))
                     {
                         Items.ItemUnitIdsToSkip[_currentProcessId].Add(item.UnitId);
                         continue;
@@ -298,11 +298,6 @@ namespace MapAssist.Helpers
                     if (item.IsValidItem && !item.IsInSocket && (checkDroppedItem || checkVendorItem || checkInventoryItem))
                     {
                         Items.LogItem(item, levelId, areaLevel, PlayerUnit.Level, _currentProcessId);
-                    }
-
-                    if (item.Item == Item.HoradricCube && !item.IsDropped)
-                    {
-                        Items.ItemUnitIdsToSkip[_currentProcessId].Add(item.UnitId);
                     }
 
                     rawItemUnits.Add(item);


### PR DESCRIPTION
This change allows the loot filter to still check unidentified items the player takes into a different game

I also removed a couple old parts of the HoradricCube check that are no longer needed