### PR TITLE
Prevent extra alerts for unid items

### DIFF
--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -265,7 +265,7 @@ namespace MapAssist.Settings
         {
             foreach (var property in GetType().GetProperties())
             {
-                if (property.Name == "Defense") continue;
+                if (SkipPropsForUnidItemCheck.Contains(property.Name)) continue;
 
                 var propType = property.PropertyType;
                 if (propType == typeof(object)) continue;
@@ -284,5 +284,18 @@ namespace MapAssist.Settings
 
             return true;
         }
+
+        private List<string> SkipPropsForUnidItemCheck = new List<string>()
+        {
+            "Defense",
+            "MinDamage",
+            "MaxDamage",
+            "MinAreaLevel",
+            "MaxAreaLevel",
+            "MinPlayerLevel",
+            "MaxPlayerLevel",
+            "MinQualityLevel",
+            "MaxQualityLevel"
+        };
     }
 }


### PR DESCRIPTION
Skips checking certain numeric item filter properties when determining if a rule targets unidentified items.  This change fixes an issue where the following rule can trigger an alert when a Magic Monarch drops and a second (unexpected) alert when the item is identified.

```yaml
Monarch:
  - Qualities: magic
    Min Area Level: 74
 ```

The list of props that are skipped can either be present on unidentified items (defense/damage) or props that aren't item stats (area/player/quality levels)
